### PR TITLE
Workaround for set file permission problem

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,7 @@
+[defaults]
+# This is required when controlling certain OSs (Ubuntu 14.04, but not 16.04)
+# when the ssh user ansible is connecting to is not the root user.
+# This applies for example to aws or azure cloud instances
+# For details, see https://docs.ansible.com/ansible/become.html#becoming-an-unprivileged-user
+# This will be resolved in ansible 2.2
+allow_world_readable_tmpfiles=True


### PR DESCRIPTION
This resolves messages like the following:
```
fatal: [galaxy2.northeurope.cloudapp.azure.com]: FAILED! => {"failed":
true, "msg": "Failed to set permissions on the temporary files Ansible
needs to create when becoming an unprivileged user. For information on
working around this, see
https://docs.ansible.com/ansible/become.html#becoming-an-unprivileged-user"}
```