### PR TITLE
Avoid #199, provide empty list if cvmfs_keys is undefined

### DIFF
--- a/roles/cloud_setup/tasks/cvmfs_client.yml
+++ b/roles/cloud_setup/tasks/cvmfs_client.yml
@@ -26,7 +26,7 @@
     owner: "root"
     group: "root"
     mode: "0444"
-  with_items: "{{ cvmfs_keys }}"
+  with_items: "{{ cvmfs_keys|default([]) }}"
 
 - name: Perform AutoFS and FUSE configuration for CernVM-FS
   command: cvmfs_config setup

--- a/roles/cloud_setup/tasks/cvmfs_client.yml
+++ b/roles/cloud_setup/tasks/cvmfs_client.yml
@@ -41,7 +41,7 @@
     owner: "root"
     group: "root"
     mode: "0644"
-  with_items: "{{ cvmfs_server_urls }}"
+  with_items: "{{ cvmfs_server_urls|default([]) }}"
 
 - name: Configure CernVM-FS client settings
   copy:


### PR DESCRIPTION
This should prevent #199 by using an empty list if cvmfs_keys are not defined.
@drosofff the travis tests should still run with ansible 2.1, so you would need to test this by hand.