### PR TITLE
Simplify configure_slurm.py.j2

### DIFF
--- a/group_vars/slurm_master
+++ b/group_vars/slurm_master
@@ -12,5 +12,3 @@ slave_node_dict:
   - {hostname: "slave-2", CPUs: "2", RealMemory: "7985"}
   - {hostname: "slave-3", CPUs: "2", RealMemory: "7985"}
 
-hostname_slave_list: ",slave-1,slave-2,slave-3" # this can be improved
-

--- a/roles/GKS-to-slurm_master_node/templates/configure_slurm.py.j2
+++ b/roles/GKS-to-slurm_master_node/templates/configure_slurm.py.j2
@@ -80,7 +80,6 @@ NodeName=$hostname CPUs=$cpus RealMemory=$memory State=UNKNOWN
 {% for host in slave_node_dict %}
 NodeName={{host.hostname}} CPUs={{host.CPUs}} RealMemory={{host.RealMemory}} State=UNKNOWN
 {% endfor %}
-#PartitionName=$partition_name Nodes=$hostname{{hostname_slave_list}} Default=YES MaxTime=INFINITE State=UP Shared=FORCE
 PartitionName=$partition_name Nodes=$hostname,{% for node in slave_node_dict -%}{{node.hostname}}{% if not loop.last -%}
 ,{% endif %}{% endfor %} Default=YES MaxTime=INFINITE State=UP Shared=FORCE
 '''

--- a/roles/GKS-to-slurm_master_node/templates/configure_slurm.py.j2
+++ b/roles/GKS-to-slurm_master_node/templates/configure_slurm.py.j2
@@ -80,7 +80,9 @@ NodeName=$hostname CPUs=$cpus RealMemory=$memory State=UNKNOWN
 {% for host in slave_node_dict %}
 NodeName={{host.hostname}} CPUs={{host.CPUs}} RealMemory={{host.RealMemory}} State=UNKNOWN
 {% endfor %}
-PartitionName=$partition_name Nodes=$hostname{{hostname_slave_list}} Default=YES MaxTime=INFINITE State=UP Shared=FORCE
+#PartitionName=$partition_name Nodes=$hostname{{hostname_slave_list}} Default=YES MaxTime=INFINITE State=UP Shared=FORCE
+PartitionName=$partition_name Nodes=$hostname,{% for node in slave_node_dict -%}{{node.hostname}}{% if not loop.last -%}
+,{% endif %}{% endfor %} Default=YES MaxTime=INFINITE State=UP Shared=FORCE
 '''
 
 try:


### PR DESCRIPTION
- by using ansible loop in configure_slurm.py.j2 over the slave_node_dict
- remove the unnecessary and ugly slave_node_dict variable