### PR TITLE
postgresql_version is now set in function of ansible_distribution_version

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -21,7 +21,8 @@ use_pbkdf2: true
 proftpd_sql_auth_type: PBKDF2
 proftpd_files_dir: "{{ galaxy_data }}/database/ftp"
 default_admin_api_key: admin
-postgresql_version: 9.3
+#postgresql_version: 9.3
+postgresql_version: "{{ '9.3' if ansible_distribution_version <= '15.04' else '9.5' }}"
 supervisor_postgres_database_path: /var/lib/postgresql/{{ postgresql_version }}/main
 supervisor_postgres_database_config: /etc/postgresql/{{ postgresql_version }}/main/postgresql.conf
 supervisor_postgres_options: "-D {{ supervisor_postgres_database_path }} -c \"config_file={{ supervisor_postgres_database_config }}\""

--- a/group_vars/all
+++ b/group_vars/all
@@ -21,7 +21,6 @@ use_pbkdf2: true
 proftpd_sql_auth_type: PBKDF2
 proftpd_files_dir: "{{ galaxy_data }}/database/ftp"
 default_admin_api_key: admin
-#postgresql_version: 9.3
 postgresql_version: "{{ '9.3' if ansible_distribution_version <= '15.04' else '9.5' }}"
 supervisor_postgres_database_path: /var/lib/postgresql/{{ postgresql_version }}/main
 supervisor_postgres_database_config: /etc/postgresql/{{ postgresql_version }}/main/postgresql.conf

--- a/group_vars/all
+++ b/group_vars/all
@@ -21,7 +21,7 @@ use_pbkdf2: true
 proftpd_sql_auth_type: PBKDF2
 proftpd_files_dir: "{{ galaxy_data }}/database/ftp"
 default_admin_api_key: admin
-postgresql_version: "{{ '9.3' if ansible_distribution_version <= '15.04' else '9.5' }}"
+postgresql_version: "{{ '9.3' if ansible_distribution_version | version_compare('15.04', '<=') else '9.5' }}"
 supervisor_postgres_database_path: /var/lib/postgresql/{{ postgresql_version }}/main
 supervisor_postgres_database_config: /etc/postgresql/{{ postgresql_version }}/main/postgresql.conf
 supervisor_postgres_options: "-D {{ supervisor_postgres_database_path }} -c \"config_file={{ supervisor_postgres_database_config }}\""


### PR DESCRIPTION
In group_vars/all postgresql_version is now set as follows

```
postgresql_version: "{{ '9.3' if ansible_distribution_version <= '15.04' else '9.5' }}"
```
@mvdbeek @remimarenco with this PR and https://github.com/galaxyproject/ansible-galaxy-extras/pull/137, I think that GKS install correctly in ubuntu 16.04. Also, specifying `supervisor_postgres_database_path`, `supervisor_postgres_database_config` and `supervisor_postgres_options` in group_vars/docker is redundant as set in group_vars/all
