### PR TITLE
Introduce proxy_env variable

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -20,3 +20,20 @@ galaxy_admin_pw: new_password
 ```
 
 As with each change, run the playbook again.
+
+
+How can I set up GalaxyKickStart behind a proxy?
+----
+
+Many commandline utilities can be configured to use a proxy by setting the
+`http_proxy` and `https_proxy` environment variables. Tasks launched by ansible
+will only see these environment variables if ansible sets these variables for
+the task. We have included a global `proxy_env` variable in the galaxy.yml playbook.
+You can set the content of this variable in your inventory. To use the proxy at
+http://proxy.bos.example.com:8080 you can define
+```
+proxy_env:
+  http_proxy: http://proxy.bos.example.com:8080
+  https_proxy: http://proxy.bos.example.com:8080
+```
+in your inventory.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -29,11 +29,13 @@ Many commandline utilities can be configured to use a proxy by setting the
 `http_proxy` and `https_proxy` environment variables. Tasks launched by ansible
 will only see these environment variables if ansible sets these variables for
 the task. We have included a global `proxy_env` variable in the galaxy.yml playbook.
-You can set the content of this variable in your inventory. To use the proxy at
-http://proxy.bos.example.com:8080 you can define
+You can set the content of this variable in your inventory or group variables 
+(See [Customizing the playbook](customizations.md) for details on how to define variable).
+To use the proxy at http://proxy.bos.example.com:8080 define the variable `proxy_env` like so:
+
 ```
 proxy_env:
   http_proxy: http://proxy.bos.example.com:8080
   https_proxy: http://proxy.bos.example.com:8080
 ```
-in your inventory.
+An example can be found in group_vars/proxy.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -37,5 +37,8 @@ To use the proxy at http://proxy.bos.example.com:8080 define the variable `proxy
 proxy_env:
   http_proxy: http://proxy.bos.example.com:8080
   https_proxy: http://proxy.bos.example.com:8080
+  no_proxy: localhost,127.0.0.0,127.0.1.1,127.0.1.1,local.home
 ```
+
+Adresses that should not be contacted through a proxy should be listed in the `no_proxy` variable.
 An example can be found in group_vars/proxy.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -117,3 +117,7 @@ Specifications for each remote target:
 * AWS
     * Image needed to deploy galaxy-kickstart: `Ubuntu Server 14.04 LTS (HVM), SSD Volume Type - ami-2d39803a`
     * Inventory: `<target Amazon Web Services IP address> ansible_ssh_user="ubuntu" ansible_ssh_private_key_file="<path/to/your/aws/private/key>"`
+
+## Deploying galaxy-kickstart behind a proxy
+
+See [How can I set up GalaxyKickStart behind a proxy?](faq.md)

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,8 @@
 - hosts: all
   become: yes
 
+  environment: "{{ proxy_env }}"
+
   handlers:
     - include: roles/handlers/galaxy.yml
       static: yes

--- a/group_vars/all
+++ b/group_vars/all
@@ -1,3 +1,4 @@
+proxy_env: {}
 install_galaxy: true
 install_maintainance_packages: false
 galaxy_hostname: "{{ inventory_hostname }}"

--- a/group_vars/proxy
+++ b/group_vars/proxy
@@ -3,3 +3,4 @@
 proxy_env:
   http_proxy: http://proxy.bos.example.com:8080
   https_proxy: http://proxy.bos.example.com:8080
+  no_proxy: localhost,127.0.0.0,127.0.1.1,127.0.1.1,local.home

--- a/group_vars/proxy
+++ b/group_vars/proxy
@@ -1,5 +1,4 @@
-## Uses default settings defined in group_vars/all, but sets the `proxy_env`
-variable.
+## Uses default settings defined in group_vars/all, but sets the `proxy_env` variable.
 
 proxy_env:
   http_proxy: http://proxy.bos.example.com:8080

--- a/group_vars/proxy
+++ b/group_vars/proxy
@@ -1,0 +1,6 @@
+## Uses default settings defined in group_vars/all, but sets the `proxy_env`
+variable.
+
+proxy_env:
+  http_proxy: http://proxy.bos.example.com:8080
+  https_proxy: http://proxy.bos.example.com:8080


### PR DESCRIPTION
The default proxy_env variable is empty, but users may modify their
inventory file to include global environment variables, such as
http_proxy and https_proxy.

A proxy_env variable may look like this:
```
proxy_env:
  http_proxy: http://proxy.bos.example.com:8080
  https_proxy: http://proxy.bos.example.com:8080
```

More documentation can be found in the Ansible Documentation at
http://docs.ansible.com/ansible/playbooks_environment.html