### PR TITLE
Fix nginx upload serving with prefix in docker

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -48,17 +48,17 @@ additional_files_list:
 
 supervisor_env_vars:
     # Use pre-exsting env vars if they are defined
-    - IP_ADDRESS=${IP_ADDRESS:-`curl --silent icanhazip.com`}
-    - MASQUERADE_ADDRESS=$IP_ADDRESS
-    - GALAXY_GID="{{ galaxy_user_gid }}"
-    - GALAXY_UID="{{ galaxy_user_uid }}"
-    - NATIVE_SPEC="--ntasks=`/usr/bin/nproc` --share"
-    - NGINX_GALAXY_LOCATION="{{ nginx_galaxy_location }}"
-    - GALAXY_CONFIG_FTP_UPLOAD_SITE="ftp://$IP_ADDRESS"
-    - GALAXY_CONFIG_NGINX_X_ACCEL_REDIRECT_BASE="$NGINX_GALAXY_LOCATION/_x_accel_redirect"
-    - GALAXY_CONFIG_NGINX_X_ARCHIVE_FILES_BASE="$NGINX_GALAXY_LOCATION/_x_accel_redirect"
-    - GALAXY_CONFIG_NGINX_UPLOAD_PATH="$NGINX_GALAXY_LOCATION/_upload"
-    - GALAXY_CONFIG_CONDA_AUTO_INIT="True"
+    - export IP_ADDRESS=${IP_ADDRESS:-`curl --silent icanhazip.com`}
+    - export MASQUERADE_ADDRESS=${MASQUERADE_ADDRESS:-$IP_ADDRESS}
+    - export GALAXY_GID="${GALAXY_GID:-{{ galaxy_user_gid }}}"
+    - export GALAXY_UID="${GALAXY_UID:-{{ galaxy_user_uid }}}"
+    - export NATIVE_SPEC="${NATIVE_SPEC:---ntasks=`/usr/bin/nproc` --share}"
+    - export NGINX_GALAXY_LOCATION="${NGINX_GALAXY_LOCATION:-{{ nginx_galaxy_location }}}"
+    - export GALAXY_CONFIG_FTP_UPLOAD_SITE="${GALAXY_CONFIG_FTP_UPLOAD_SITE:-ftp://$IP_ADDRESS}"
+    - export GALAXY_CONFIG_NGINX_X_ACCEL_REDIRECT_BASE="${GALAXY_CONFIG_NGINX_X_ACCEL_REDIRECT_BASE:-$NGINX_GALAXY_LOCATION/_x_accel_redirect}"
+    - export GALAXY_CONFIG_NGINX_X_ARCHIVE_FILES_BASE="{$GALAXY_CONFIG_NGINX_X_ARCHIVE_FILES_BASE:-$NGINX_GALAXY_LOCATION/_x_accel_redirect}"
+    - export GALAXY_CONFIG_NGINX_UPLOAD_PATH="${GALAXY_CONFIG_NGINX_UPLOAD_PATH:-$NGINX_GALAXY_LOCATION/_upload}"
+    - export GALAXY_CONFIG_CONDA_AUTO_INIT="${GALAXY_CONFIG_CONDA_AUTO_INIT:-True}"
 
 # galaxy role variables
 

--- a/group_vars/all
+++ b/group_vars/all
@@ -47,17 +47,18 @@ additional_files_list:
   - { src: "extra-files/tool_sheds_conf.xml", dest: "{{ galaxy_config_dir }}" }
 
 supervisor_env_vars:
-    - export IP_ADDRESS=`curl --silent icanhazip.com`
-    - export MASQUERADE_ADDRESS=$IP_ADDRESS
-    - export GALAXY_GID="{{ galaxy_user_gid }}"
-    - export GALAXY_UID="{{ galaxy_user_uid }}"
-    - export NATIVE_SPEC="--ntasks=`/usr/bin/nproc` --share"
-    - export NGINX_GALAXY_LOCATION="{{ nginx_galaxy_location }}"
-    - export GALAXY_CONFIG_FTP_UPLOAD_SITE="ftp://$IP_ADDRESS"
-    - export GALAXY_CONFIG_NGINX_X_ACCEL_REDIRECT_BASE="$NGINX_GALAXY_LOCATION/_x_accel_redirect"
-    - export GALAXY_CONFIG_NGINX_X_ARCHIVE_FILES_BASE="$NGINX_GALAXY_LOCATION/_x_accel_redirect"
-    - export GALAXY_CONFIG_NGINX_UPLOAD_PATH="$NGINX_GALAXY_LOCATION/_upload"
-    - export GALAXY_CONFIG_CONDA_AUTO_INIT="True"
+    # Use pre-exsting env vars if they are defined
+    - IP_ADDRESS=${IP_ADDRESS:-`curl --silent icanhazip.com`}
+    - MASQUERADE_ADDRESS=$IP_ADDRESS
+    - GALAXY_GID="{{ galaxy_user_gid }}"
+    - GALAXY_UID="{{ galaxy_user_uid }}"
+    - NATIVE_SPEC="--ntasks=`/usr/bin/nproc` --share"
+    - NGINX_GALAXY_LOCATION="{{ nginx_galaxy_location }}"
+    - GALAXY_CONFIG_FTP_UPLOAD_SITE="ftp://$IP_ADDRESS"
+    - GALAXY_CONFIG_NGINX_X_ACCEL_REDIRECT_BASE="$NGINX_GALAXY_LOCATION/_x_accel_redirect"
+    - GALAXY_CONFIG_NGINX_X_ARCHIVE_FILES_BASE="$NGINX_GALAXY_LOCATION/_x_accel_redirect"
+    - GALAXY_CONFIG_NGINX_UPLOAD_PATH="$NGINX_GALAXY_LOCATION/_upload"
+    - GALAXY_CONFIG_CONDA_AUTO_INIT="True"
 
 # galaxy role variables
 

--- a/roles/set_supervisor_env_vars/tasks/main.yml
+++ b/roles/set_supervisor_env_vars/tasks/main.yml
@@ -16,3 +16,4 @@
   service: name=supervisor state=restarted
   when: env_var_task.changed
   ignore_errors: yes
+  tags: skip_supervisor_start_in_docker

--- a/startup.sh
+++ b/startup.sh
@@ -3,12 +3,12 @@
 # then source this file (to get both user-specified and default environemntal variables)
 # and run ansible to adjust runtime settings. The argument to startup.sh is the location of
 # the inventory file to be used
-printenv >> /etc/default/supervisor && source /etc/default/supervisor && \
-           ansible-playbook galaxy.yml -c local \
-           --tags "persists_galaxy,nginx_config,galaxy_config_files,galaxy_extras_job_conf" --skip-tags=skip_supervisor_start_in_docker \
-           --extra-vars nginx_galaxy_location=$NGINX_GALAXY_LOCATION \
-           --extra-vars galaxy_admin=$GALAXY_CONFIG_ADMIN_USERS \
-           --extra-vars ftp_upload_site=$IP_ADDRESS \
-           --extra-vars nat_masquerade=$NAT_MAQUERADE \
-           -i "$1" && \
-           exec /usr/bin/supervisord -c /etc/supervisor/supervisord.conf --nodaemon
+ansible-playbook galaxy.yml -c local \
+    --tags "persists_galaxy,nginx_config,galaxy_config_files,galaxy_extras_job_conf,env_vars" --skip-tags=skip_supervisor_start_in_docker \
+    --extra-vars nginx_galaxy_location=$NGINX_GALAXY_LOCATION \
+    --extra-vars galaxy_admin=$GALAXY_CONFIG_ADMIN_USERS \
+    --extra-vars ftp_upload_site=$IP_ADDRESS \
+    --extra-vars nat_masquerade=$NAT_MAQUERADE \
+    -i "$1" && \
+    source /etc/default/supervisor && \
+    exec /usr/bin/supervisord -c /etc/supervisor/supervisord.conf --nodaemon


### PR DESCRIPTION
This was reported by @remimarenco on gitter. The problem is that we are
are setting the environment variables
`GALAXY_CONFIG_NGINX_X_ACCEL_REDIRECT_BASE`,
`GALAXY_CONFIG_NGINX_X_ARCHIVE_FILES_BASE`,
and `GALAXY_CONFIG_NGINX_UPLOAD_PATH` as a composite of
NGINX_GALAXY_LOCATION plus the specific path. In docker we are appending
all current (i.e user-specified variables) to /etc/default/supervisor
and then we source these variables. The problem is that by default we
are setting NGINX_GALAXY_LOCATION="" (i.e no prefix). The following
order would be sourced currently:

```
NGINX_GALAXY_LOCATION=""
GALAXY_CONFIG_NGINX_X_ACCEL_REDIRECT_BASE="$NGINX_GALAXY_LOCATION/_x_accel_redirect"
GALAXY_CONFIG_NGINX_X_ARCHIVE_FILES_BASE="$NGINX_GALAXY_LOCATION/_x_accel_redirect"
NGINX_GALAXY_LOCATION="my-subirectory"
```

This breaks uploading and downloading files for instances with a proxy
prefix, while they appear otherwise functional.

The new approach is to not append the current env vars in the docker
startup script, but to set these variables via ansible. Sourcing
/etc/default/supervisor before starting supervisor will then load the
environment variables into the current session.