### PR TITLE
Install bioblend with fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ before_install:
   galaxy_kickstart`
 - docker ps
 install:
-- sudo su $GALAXY_TRAVIS_USER -c 'pip install --user bioblend[testing]'
+  - sudo su $GALAXY_TRAVIS_USER -c 'pip install --user https://github.com/mvdbeek/bioblend/archive/test_data.zip pytest'
 script:
 - sleep 60s
 - docker logs $CID2

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ before_install:
 - export GALAXY_USER_PASSWD=admin
 - export BIOBLEND_GALAXY_API_KEY=admin
 - export BIOBLEND_GALAXY_URL=http://localhost:8080
+- export BIOBLEND_TEST_JOB_TIMEOUT=120
 - docker --version
 - docker info
 - pip install ansible


### PR DESCRIPTION
This bioblend fork actually installs the test data and sets the correct exit code if tests are failing. (https://github.com/galaxyproject/bioblend/pull/238)