### PR TITLE
17_05 autoinstall conda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ before_install:
   galaxy_kickstart`
 - docker ps
 install:
-  - sudo su $GALAXY_TRAVIS_USER -c 'pip install --user https://github.com/mvdbeek/bioblend/archive/test_data.zip pytest'
+  - sudo su $GALAXY_TRAVIS_USER -c 'pip install --user https://github.com/galaxyproject/bioblend/archive/master.zip pytest'
 script:
 - sleep 60s
 - docker logs $CID2

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -42,10 +42,10 @@
         - install_galaxy
         - manage_postgres
 
-    - role: miniconda-role
-      tags: conda
-      become: yes
-      become_user: "{{ galaxy_user_name }}"
+#    - role: miniconda-role
+#      tags: conda
+#      become: yes
+#      become_user: "{{ galaxy_user_name }}"
 
     - role: galaxyprojectdotorg.galaxy
       become: yes

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -42,10 +42,10 @@
         - install_galaxy
         - manage_postgres
 
-#    - role: miniconda-role
-#      tags: conda
-#      become: yes
-#      become_user: "{{ galaxy_user_name }}"
+    - role: miniconda-role
+      tags: conda
+      become: yes
+      become_user: "{{ galaxy_user_name }}"
 
     - role: galaxyprojectdotorg.galaxy
       become: yes

--- a/group_vars/all
+++ b/group_vars/all
@@ -1,7 +1,7 @@
 proxy_env: {}
 install_galaxy: true
 install_maintainance_packages: false
-galaxy_manage_trackster: true
+galaxy_manage_trackster: false
 galaxy_hostname: "{{ inventory_hostname }}"
 nginx_galaxy_location: ""
 galaxy_user_name: galaxy
@@ -84,6 +84,7 @@ galaxy_config:
     allow_user_dataset_purge: True
     allow_user_impersonation: True
     enable_quotas: True
+    conda_auto_init = True
     allow_user_deletion: True
     tool_sheds_config_file: "{{ galaxy_config_dir }}/tool_sheds_conf.xml"
     static_enabled: False

--- a/group_vars/all
+++ b/group_vars/all
@@ -1,7 +1,7 @@
 proxy_env: {}
 install_galaxy: true
 install_maintainance_packages: false
-galaxy_manage_trackster: false
+galaxy_manage_trackster: true
 galaxy_hostname: "{{ inventory_hostname }}"
 nginx_galaxy_location: ""
 galaxy_user_name: galaxy
@@ -84,7 +84,6 @@ galaxy_config:
     allow_user_dataset_purge: True
     allow_user_impersonation: True
     enable_quotas: True
-    conda_auto_init: True
     allow_user_deletion: True
     tool_sheds_config_file: "{{ galaxy_config_dir }}/tool_sheds_conf.xml"
     static_enabled: False

--- a/group_vars/all
+++ b/group_vars/all
@@ -84,7 +84,7 @@ galaxy_config:
     allow_user_dataset_purge: True
     allow_user_impersonation: True
     enable_quotas: True
-    conda_auto_init = True
+    conda_auto_init: True
     allow_user_deletion: True
     tool_sheds_config_file: "{{ galaxy_config_dir }}/tool_sheds_conf.xml"
     static_enabled: False


### PR DESCRIPTION
I am not sure the miniconda role is required anymore. At least in this PR, it does not seem to be required.
Importantly it fixes the nasty bug I mentioned to @mvdbeek at gcc2017 with the new msp_sr_bowtie wrapper (skipping need of a python wrapper)

I would remove the commented lines and put back trackster install to True if Merge PR