### PR TITLE
pin galaxy-extras to commit 03e894feface65f9b4c0df1a41fb70c1fe8db159

### DIFF
--- a/requirements_roles.yml
+++ b/requirements_roles.yml
@@ -12,6 +12,7 @@
 
 - src: https://github.com/galaxyproject/ansible-galaxy-extras.git
   name: galaxyprojectdotorg.galaxy-extras
+  version: 03e894feface65f9b4c0df1a41fb70c1fe8db159
 
 - src: https://github.com/galaxyproject/ansible-trackster.git
   name: galaxyprojectdotorg.trackster


### PR DESCRIPTION
This will temporally pin ansible-galaxy-extras whose PR [160](https://github.com/galaxyproject/ansible-galaxy-extras/pull/160) broke the GKS travis test at docker container build.