### PR TITLE
go back to the galaxyproject ansible-galaxy-tools repo

### DIFF
--- a/requirements_roles.yml
+++ b/requirements_roles.yml
@@ -16,7 +16,7 @@
 - src: https://github.com/galaxyproject/ansible-trackster.git
   name: galaxyprojectdotorg.trackster
 
-- src: https://github.com/ARTbio/ansible-galaxy-tools.git
+- src: https://github.com/galaxyproject/ansible-galaxy-tools.git
   name: galaxyprojectdotorg.galaxy-tools
 
 - src: https://github.com/uchida/ansible-miniconda-role.git


### PR DESCRIPTION
, now that the problematic handler is optional