### PR TITLE
specify http:// in galaxy_tools_galaxy_instance_url

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -151,7 +151,7 @@ galaxy_tools_admin_user_password: "{{ galaxy_admin_pw }}"
 galaxy_tools_admin_user_preset_api_key: yes
 galaxy_tools_api_key: "{{ default_admin_api_key }}"
 galaxy_tools_create_bootstrap_user: yes
-galaxy_tools_galaxy_instance_url: "{{ galaxy_hostname }}"
+galaxy_tools_galaxy_instance_url: http://"{{ galaxy_hostname }}"
 galaxy_tools_tool_list_files: []
 galaxy_tools_install_workflows: true
 galaxy_tools_workflows: []


### PR DESCRIPTION
Because of recent changes in ansible-galaxy-tools (https://github.com/galaxyproject/ansible-galaxy-tools/pull/51)