### PR TITLE
Adjust path to reports sample for 17.09

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -18,6 +18,7 @@ galaxy_database: /home/galaxy_database
 galaxy_db: postgresql://{{ galaxy_user_name }}:{{ galaxy_user_name }}@localhost:5432/galaxy?client_encoding=utf8
 galaxy_git_repo: https://github.com/galaxyproject/galaxy.git
 galaxy_changeset_id: release_17.09
+galaxy_reports_config_file: "{{ galaxy_config_dir }}/reports.yml.sample"  # Change this to "{{ galaxy_config_dir }}/reports.ini.sample" for galaxy < 17.09
 galaxy_admin: admin@galaxy.org
 galaxy_admin_pw: admin
 use_pbkdf2: true


### PR DESCRIPTION
The reports.ini.sample file has been replaced by reports.yml.sample in 17.09
(https://github.com/galaxyproject/galaxy/commit/102566dd5e1c5903726057f1077a1d7fc614b815)