### PR TITLE
Slowly moving metavisitor-2.0 toward run-data-managers

### DIFF
--- a/extra-files/metavisitor/metavisitor_run_data_managers.yaml
+++ b/extra-files/metavisitor/metavisitor_run_data_managers.yaml
@@ -1,36 +1,71 @@
 # configuration for fetch and index genomes
 
+genomes:
+    - accession: NC_001617.1
+      name: RhinoVirus A (NC_001617.1)
+      id: RhinoVirusA
+    - accession: AC_000007.1
+      name: Human adenovirus 2 (AC_000007.1)
+      id: HumAdeno2
+    - accession: KF039736.1
+      name: Norovirus Hu/GI.1/CHA7A011/2010/USA
+      id: NoroVirCHA7A011
+
+
 data_managers:
     # Data manager ID
+
     - id: toolshed.g2.bx.psu.edu/repos/devteam/data_manager_fetch_genome_dbkeys_all_fasta/data_manager_fetch_genome_all_fasta_dbkey/0.0.2
-      # tool parameters, nested parameters should be specified using a pipe (|)
       params:
-        - 'dbkey_source|dbkey': '{{ item }}'
-        - 'reference_source|reference_source_selector': 'ucsc'
-        - 'reference_source|requested_dbkey': '{{ item }}'
-      # Items refere to a list of variables you want to run this data manager. You can use them inside the param field with {{ item }}
-      # In case of genome for example you can run this DM with multiple genomes, or you could give multiple URLs.
-      items:
-        - dm6
-        #- mm9
-      # Name of the data-tables you want to reload after your DM are finished. This can be important for subsequent data managers
+        - 'dbkey_source|dbkey_source_selector': 'new'
+        - 'dbkey_source|dbkey': '{{ item.id }}'
+        - 'dbkey_source|dbkey_name': '{{ item.name }}'
+        - 'sequence_name': '{{ item.name }}'
+        - 'sequence_id': '{{ item.id }}'
+        - 'reference_source|reference_source_selector': 'ncbi'
+        - 'reference_source|requested_identifier': '{{ item.accession }}'
+      items: "{{ genomes }}"
       data_table_reload:
         - all_fasta
         - __dbkeys__
 
-    - id: toolshed.g2.bx.psu.edu/repos/iuc/data_manager_bowtie_index_builder/bowtie_index_builder_data_manager/1.2.0
+    - id: sam_fasta_index_builder
       params:
         - 'all_fasta_source': '{{ item.id }}'
         - 'sequence_name': '{{ item.name }}'
         - 'sequence_id': '{{ item.id }}'
-      items:
-        - id: dm6
-          name: D. melanogaster Aug. 2014 (BDGP r6/dm6)
+      items: "{{ genomes }}"
+      data_table_reload:
+        - fasta_indexes
+#    - id: toolshed.g2.bx.psu.edu/repos/devteam/data_manager_fetch_genome_dbkeys_all_fasta/data_manager_fetch_genome_all_fasta_dbkey/0.0.2
+#      # tool parameters, nested parameters should be specified using a pipe (|)
+#      params:
+#        - 'dbkey_source|dbkey': '{{ item }}'
+#        - 'reference_source|reference_source_selector': 'ucsc'
+#        - 'reference_source|requested_dbkey': '{{ item }}'
+#      # Items refere to a list of variables you want to run this data manager. You can use them inside the param field with {{ item }}
+#      # In case of genome for example you can run this DM with multiple genomes, or you could give multiple URLs.
+#      items:
+#        - dm6
+        #- mm9
+      # Name of the data-tables you want to reload after your DM are finished. This can be important for subsequent data managers
+#      data_table_reload:
+#        - all_fasta
+#        - __dbkeys__
+
+#    - id: toolshed.g2.bx.psu.edu/repos/iuc/data_manager_bowtie_index_builder/bowtie_index_builder_data_manager/1.2.0
+#      params:
+#        - 'all_fasta_source': '{{ item.id }}'
+#        - 'sequence_name': '{{ item.name }}'
+#        - 'sequence_id': '{{ item.id }}'
+#      items:
+#        - id: dm6
+#          name: D. melanogaster Aug. 2014 (BDGP r6/dm6)
 #        - id: mm9
 #          name: M. musculus July 2007 (NCBI37/mm9)
-      data_table_reload:
-        # Bowtie creates indices for Bowtie and TopHat
-        - bowtie_indexes
+#      data_table_reload:
+#        # Bowtie creates indices for Bowtie and TopHat
+#        - bowtie_indexes
 
 
       

--- a/extra-files/metavisitor/metavisitor_run_data_managers.yaml
+++ b/extra-files/metavisitor/metavisitor_run_data_managers.yaml
@@ -1,0 +1,52 @@
+# configuration for fetch and index genomes
+
+data_managers:
+    # Data manager ID
+    - id: toolshed.g2.bx.psu.edu/repos/devteam/data_manager_fetch_genome_dbkeys_all_fasta/data_manager_fetch_genome_all_fasta_dbkey/0.0.2
+      # tool parameters, nested parameters should be specified using a pipe (|)
+      params:
+        - 'dbkey_source|dbkey': '{{ item }}'
+        - 'reference_source|reference_source_selector': 'ucsc'
+        - 'reference_source|requested_dbkey': '{{ item }}'
+      # Items refere to a list of variables you want to run this data manager. You can use them inside the param field with {{ item }}
+      # In case of genome for example you can run this DM with multiple genomes, or you could give multiple URLs.
+      items:
+        - dm6
+        #- mm9
+      # Name of the data-tables you want to reload after your DM are finished. This can be important for subsequent data managers
+      data_table_reload:
+        - all_fasta
+        - __dbkeys__
+
+    - id: toolshed.g2.bx.psu.edu/repos/iuc/data_manager_bowtie_index_builder/bowtie_index_builder_data_manager/1.2.0
+      params:
+        - 'all_fasta_source': '{{ item.id }}'
+        - 'sequence_name': '{{ item.name }}'
+        - 'sequence_id': '{{ item.id }}'
+      items:
+        - id: dm6
+          name: D. melanogaster Aug. 2014 (BDGP r6/dm6)
+#        - id: mm9
+#          name: M. musculus July 2007 (NCBI37/mm9)
+      data_table_reload:
+        # Bowtie creates indices for Bowtie and TopHat
+        - bowtie_indexes
+
+
+      
+#    - id: toolshed.g2.bx.psu.edu/repos/devteam/data_manager_bowtie2_index_builder/bowtie2_index_builder_data_manager/2.2.6
+#      params:
+#        - 'all_fasta_source': '{{ item.id }}'
+#        - 'sequence_name': '{{ item.name }}'
+#        - 'sequence_id': '{{ item.id }}'
+#      items:
+#        - id: ce8
+#          name: C. elegans (ce8)
+#        - id: dm3
+#          name: D. melanogaster Apr. 2006 (BDGP r5/dm3)
+#        - id: mm9
+#          name: M. musculus July 2007 (NCBI37/mm9)
+#      data_table_reload:
+#        # Bowtie creates indices for Bowtie and TopHat
+#        - bowtie2_indexes
+#        - tophat2_indexes

--- a/extra-files/metavisitor/metavisitor_run_data_managers.yaml
+++ b/extra-files/metavisitor/metavisitor_run_data_managers.yaml
@@ -1,87 +1,45 @@
 # configuration for fetch and index genomes
 
 genomes:
-    - accession: NC_001617.1
-      name: RhinoVirus A (NC_001617.1)
-      id: RhinoVirusA
-    - accession: AC_000007.1
-      name: Human adenovirus 2 (AC_000007.1)
-      id: HumAdeno2
-    - accession: KF039736.1
-      name: Norovirus Hu/GI.1/CHA7A011/2010/USA
-      id: NoroVirCHA7A011
+    - accession: dm6
+      name: Drosophila melanogaster Release 6
+      id: dm6
 
 
 data_managers:
     # Data manager ID
 
-    - id: toolshed.g2.bx.psu.edu/repos/devteam/data_manager_fetch_genome_dbkeys_all_fasta/data_manager_fetch_genome_all_fasta_dbkey/0.0.2
+    - id: fetch_genome_all_fasta_dbkeys
       params:
         - 'dbkey_source|dbkey_source_selector': 'new'
         - 'dbkey_source|dbkey': '{{ item.id }}'
         - 'dbkey_source|dbkey_name': '{{ item.name }}'
         - 'sequence_name': '{{ item.name }}'
         - 'sequence_id': '{{ item.id }}'
-        - 'reference_source|reference_source_selector': 'ncbi'
+        - 'reference_source|reference_source_selector': 'ucsc'
         - 'reference_source|requested_identifier': '{{ item.accession }}'
       items: "{{ genomes }}"
       data_table_reload:
         - all_fasta
         - __dbkeys__
 
-    - id: sam_fasta_index_builder
+    - id: bowtie_index_builder
       params:
         - 'all_fasta_source': '{{ item.id }}'
         - 'sequence_name': '{{ item.name }}'
         - 'sequence_id': '{{ item.id }}'
       items: "{{ genomes }}"
       data_table_reload:
-        - fasta_indexes
-#    - id: toolshed.g2.bx.psu.edu/repos/devteam/data_manager_fetch_genome_dbkeys_all_fasta/data_manager_fetch_genome_all_fasta_dbkey/0.0.2
-#      # tool parameters, nested parameters should be specified using a pipe (|)
-#      params:
-#        - 'dbkey_source|dbkey': '{{ item }}'
-#        - 'reference_source|reference_source_selector': 'ucsc'
-#        - 'reference_source|requested_dbkey': '{{ item }}'
-#      # Items refere to a list of variables you want to run this data manager. You can use them inside the param field with {{ item }}
-#      # In case of genome for example you can run this DM with multiple genomes, or you could give multiple URLs.
-#      items:
-#        - dm6
-        #- mm9
-      # Name of the data-tables you want to reload after your DM are finished. This can be important for subsequent data managers
-#      data_table_reload:
-#        - all_fasta
-#        - __dbkeys__
-
-#    - id: toolshed.g2.bx.psu.edu/repos/iuc/data_manager_bowtie_index_builder/bowtie_index_builder_data_manager/1.2.0
-#      params:
-#        - 'all_fasta_source': '{{ item.id }}'
-#        - 'sequence_name': '{{ item.name }}'
-#        - 'sequence_id': '{{ item.id }}'
-#      items:
-#        - id: dm6
-#          name: D. melanogaster Aug. 2014 (BDGP r6/dm6)
-#        - id: mm9
-#          name: M. musculus July 2007 (NCBI37/mm9)
-#      data_table_reload:
-#        # Bowtie creates indices for Bowtie and TopHat
-#        - bowtie_indexes
-
+        # Bowtie creates indices for Bowtie and TopHat
+        - bowtie_indexes
 
       
-#    - id: toolshed.g2.bx.psu.edu/repos/devteam/data_manager_bowtie2_index_builder/bowtie2_index_builder_data_manager/2.2.6
-#      params:
-#        - 'all_fasta_source': '{{ item.id }}'
-#        - 'sequence_name': '{{ item.name }}'
-#        - 'sequence_id': '{{ item.id }}'
-#      items:
-#        - id: ce8
-#          name: C. elegans (ce8)
-#        - id: dm3
-#          name: D. melanogaster Apr. 2006 (BDGP r5/dm3)
-#        - id: mm9
-#          name: M. musculus July 2007 (NCBI37/mm9)
-#      data_table_reload:
-#        # Bowtie creates indices for Bowtie and TopHat
-#        - bowtie2_indexes
-#        - tophat2_indexes
+    - id: bowtie2_index_builder
+      params:
+        - 'all_fasta_source': '{{ item.id }}'
+        - 'sequence_name': '{{ item.name }}'
+        - 'sequence_id': '{{ item.id }}'
+      items: "{{ genomes }}"
+      data_table_reload:
+        # Bowtie creates indices for Bowtie and TopHat
+        - bowtie2_indexes

--- a/extra-files/metavisitor/metavisitor_tool_list.yml.fortestonly
+++ b/extra-files/metavisitor/metavisitor_tool_list.yml.fortestonly
@@ -1,65 +1,27 @@
 tools:
-- name: blast_to_scaffold
-  owner: artbio
+- name: data_manager_bowtie_index_builder
+  owner: iuc
   revisions:
-  - 7d96b28eec49
-  tool_panel_section_label: Metavisitor
-  tool_shed_url: https://toolshed.g2.bx.psu.edu/
-
-- name: cherry_pick_fasta
-  owner: artbio
-  revisions:
-  - e3aee4ba49c6
-  tool_panel_section_label: Metavisitor
-  tool_shed_url: https://toolshed.g2.bx.psu.edu/
-
-- name: concatenate_multiple_datasets
-  owner: mvdbeek
-  revisions:
-  - 201c568972c3
-  tool_panel_section_label: Metavisitor
-  tool_shed_url: https://toolshed.g2.bx.psu.edu/
-
-- name: fasta_filter_by_length
-  owner: devteam
-  revisions:
-  - 2fd6033d0e9c
-  tool_panel_section_label: Metavisitor
-  tool_shed_url: https://toolshed.g2.bx.psu.edu/
-
-- name: fastqtofasta
-  owner: devteam
-  revisions:
-  - 4844c1810c16
-  tool_panel_section_label: Metavisitor
+  - 86e9af693a33
+  tool_panel_section_label: null
   tool_shed_url: https://toolshed.g2.bx.psu.edu/
   install_resolver_dependencies: True
   install_tool_dependencies: False
 
-- name: fetch_fasta_from_ncbi
-  owner: artbio
+- name: data_manager_fetch_genome_dbkeys_all_fasta
+  owner: devteam
   revisions:
-  - c667d0ee39f5
-  tool_panel_section_label: Metavisitor
+  - b1bc53e9bbc5
+  tool_panel_section_label: null
   tool_shed_url: https://toolshed.g2.bx.psu.edu/
+  install_resolver_dependencies: True
+  install_tool_dependencies: False
 
-- name: blastparser_and_hits
+- name: sr_bowtie
   owner: artbio
   revisions:
-  - 9dfb65ebb02e
+  - 5f4fbba31b6a
   tool_panel_section_label: Metavisitor
   tool_shed_url: https://toolshed.g2.bx.psu.edu/
-
-- name: sequence_format_converter
-  owner: artbio
-  revisions:
-  - a8aacccd79a3
-  tool_panel_section_label: Metavisitor
-  tool_shed_url: https://toolshed.g2.bx.psu.edu/
-
-- name: yac_clipper
-  owner: artbio
-  revisions:
-  - 7c913274e22a
-  tool_panel_section_label: Metavisitor
-  tool_shed_url: https://toolshed.g2.bx.psu.edu/
+  install_resolver_dependencies: True
+  install_tool_dependencies: False

--- a/extra-files/metavisitor/metavisitor_tool_list.yml.fortestonly
+++ b/extra-files/metavisitor/metavisitor_tool_list.yml.fortestonly
@@ -1,27 +1,11 @@
 tools:
-- name: data_manager_bowtie_index_builder
-  owner: iuc
-  revisions:
-  - 86e9af693a33
-  tool_panel_section_label: null
-  tool_shed_url: https://toolshed.g2.bx.psu.edu/
-  install_resolver_dependencies: True
-  install_tool_dependencies: False
+
+- name: data_manager_sam_fasta_index_builder
+  owner: devteam
 
 - name: data_manager_fetch_genome_dbkeys_all_fasta
   owner: devteam
-  revisions:
-  - b1bc53e9bbc5
   tool_panel_section_label: null
-  tool_shed_url: https://toolshed.g2.bx.psu.edu/
-  install_resolver_dependencies: True
-  install_tool_dependencies: False
-
-- name: sr_bowtie
-  owner: artbio
-  revisions:
-  - 5f4fbba31b6a
-  tool_panel_section_label: Metavisitor
   tool_shed_url: https://toolshed.g2.bx.psu.edu/
   install_resolver_dependencies: True
   install_tool_dependencies: False

--- a/extra-files/metavisitor/metavisitor_tool_list.yml.fortestonly
+++ b/extra-files/metavisitor/metavisitor_tool_list.yml.fortestonly
@@ -1,11 +1,10 @@
 tools:
 
-- name: data_manager_sam_fasta_index_builder
-  owner: devteam
-
 - name: data_manager_fetch_genome_dbkeys_all_fasta
   owner: devteam
-  tool_panel_section_label: null
-  tool_shed_url: https://toolshed.g2.bx.psu.edu/
-  install_resolver_dependencies: True
-  install_tool_dependencies: False
+
+- name: data_manager_bowtie_index_builder
+  owner: iuc
+
+- name: data_manager_bowtie2_index_builder
+  owner: devteam

--- a/group_vars/all
+++ b/group_vars/all
@@ -151,7 +151,7 @@ galaxy_tools_admin_user_password: "{{ galaxy_admin_pw }}"
 galaxy_tools_admin_user_preset_api_key: yes
 galaxy_tools_api_key: "{{ default_admin_api_key }}"
 galaxy_tools_create_bootstrap_user: yes
-galaxy_tools_galaxy_instance_url: "{{ galaxy_hostname }}"
+galaxy_tools_galaxy_instance_url: "http://{{ galaxy_hostname }}"
 galaxy_tools_tool_list_files: []
 galaxy_tools_install_workflows: true
 galaxy_tools_workflows: []

--- a/group_vars/all
+++ b/group_vars/all
@@ -2,7 +2,7 @@ GKS: true
 proxy_env: {}
 install_galaxy: true
 install_maintainance_packages: false
-galaxy_manage_trackster: true
+galaxy_manage_trackster: false
 galaxy_hostname: "{{ inventory_hostname }}"
 nginx_galaxy_location: ""
 galaxy_user_name: galaxy

--- a/group_vars/all
+++ b/group_vars/all
@@ -89,6 +89,7 @@ galaxy_config:
     allow_user_deletion: True
     allow_library_path_paste: True
     tool_sheds_config_file: "{{ galaxy_config_dir }}/tool_sheds_conf.xml"
+    watch_tool_data_dir: True
     static_enabled: False
     nginx_upload_store: "{{ nginx_upload_store_path }}"
     use_pbkdf2: "{{ use_pbkdf2 }}"

--- a/group_vars/metavisitor
+++ b/group_vars/metavisitor
@@ -1,5 +1,9 @@
 galaxy_tools_tool_list_files:
   - "extra-files/metavisitor/metavisitor_tool_list.yml"
+
+galaxy_tools_install_data_managers: yes
+galaxy_tools_data_managers_list: "extra-files/metavisitor/metavisitor_run_data_managers.yaml"
+
 galaxy_tools_workflows:
   - "extra-files/metavisitor/Galaxy-Workflow-Metavisitor__Workflow_for_remapping_in_Use_Cases_1-1,2,3.ga"
   - "extra-files/metavisitor/Galaxy-Workflow-Metavisitor__Workflow_for_remapping_in_Use_Cases_2-1,2.ga"

--- a/group_vars/metavisitor
+++ b/group_vars/metavisitor
@@ -1,8 +1,8 @@
 galaxy_tools_tool_list_files:
   - "extra-files/metavisitor/metavisitor_tool_list.yml"
 
-galaxy_restart_handler_enabled: yes
-galaxy_tools_install_data_managers: yes
+galaxy_restart_handler_enabled: no
+galaxy_tools_install_data_managers: no
 galaxy_tools_data_managers_list: "extra-files/metavisitor/metavisitor_run_data_managers.yaml"
 
 galaxy_tools_workflows:

--- a/group_vars/metavisitor
+++ b/group_vars/metavisitor
@@ -1,6 +1,7 @@
 galaxy_tools_tool_list_files:
   - "extra-files/metavisitor/metavisitor_tool_list.yml"
 
+galaxy_restart_handler_enabled: yes
 galaxy_tools_install_data_managers: yes
 galaxy_tools_data_managers_list: "extra-files/metavisitor/metavisitor_run_data_managers.yaml"
 

--- a/group_vars/metavisitor
+++ b/group_vars/metavisitor
@@ -1,7 +1,7 @@
 galaxy_tools_tool_list_files:
   - "extra-files/metavisitor/metavisitor_tool_list.yml"
 
-galaxy_restart_handler_enabled: yes
+galaxy_restart_handler_enabled: no
 galaxy_tools_install_data_managers: yes
 galaxy_tools_data_managers_list: "extra-files/metavisitor/metavisitor_run_data_managers.yaml"
 

--- a/group_vars/metavisitor
+++ b/group_vars/metavisitor
@@ -1,7 +1,7 @@
 galaxy_tools_tool_list_files:
   - "extra-files/metavisitor/metavisitor_tool_list.yml"
 
-galaxy_restart_handler_enabled: no
+galaxy_restart_handler_enabled: yes
 galaxy_tools_install_data_managers: yes
 galaxy_tools_data_managers_list: "extra-files/metavisitor/metavisitor_run_data_managers.yaml"
 

--- a/requirements_roles.yml
+++ b/requirements_roles.yml
@@ -16,8 +16,11 @@
 - src: https://github.com/galaxyproject/ansible-trackster.git
   name: galaxyprojectdotorg.trackster
 
-- src: https://github.com/galaxyproject/ansible-galaxy-tools.git
-  name: galaxyprojectdotorg.galaxy-tools
+#- src: https://github.com/galaxyproject/ansible-galaxy-tools.git
+#  name: galaxyprojectdotorg.galaxy-tools
 
+- src: https://github.com/ARTbio/ansible-galaxy-tools.git
+  name: galaxyprojectdotorg.galaxy-tools
+  version: dev
 - src: https://github.com/uchida/ansible-miniconda-role.git
   name: miniconda-role

--- a/requirements_roles.yml
+++ b/requirements_roles.yml
@@ -16,11 +16,8 @@
 - src: https://github.com/galaxyproject/ansible-trackster.git
   name: galaxyprojectdotorg.trackster
 
-#- src: https://github.com/galaxyproject/ansible-galaxy-tools.git
-#  name: galaxyprojectdotorg.galaxy-tools
-
-- src: https://github.com/ARTbio/ansible-galaxy-tools.git
+- src: https://github.com/galaxyproject/ansible-galaxy-tools.git
   name: galaxyprojectdotorg.galaxy-tools
-  version: dev
+
 - src: https://github.com/uchida/ansible-miniconda-role.git
   name: miniconda-role

--- a/travis_scripts/before_install_ansible.sh
+++ b/travis_scripts/before_install_ansible.sh
@@ -5,7 +5,7 @@ sudo apt-get -y --purge remove postgresql libpq-dev libpq5 postgresql-client-com
 sudo rm -rf /var/lib/postgresql
 sudo apt-get update -qq
 pip --version
-pip install ansible==2.2
+pip install ansible
 ansible-galaxy install -r requirements_roles.yml -p roles
 mv extra-files/metavisitor/metavisitor_tool_list.yml.fortestonly extra-files/metavisitor/metavisitor_tool_list.yml
 sudo groupadd -r $GALAXY_TRAVIS_USER -g $GALAXY_GID

--- a/travis_scripts/before_install_docker.sh
+++ b/travis_scripts/before_install_docker.sh
@@ -16,7 +16,7 @@ docker build -t metavisitor .
 sudo mkdir /export && sudo chown $GALAXY_UID:$GALAXY_GID /export
 sudo mkdir /export2 && sudo chown $GALAXY_UID:$GALAXY_GID /export2
 export STANDARD=`docker run -d \
-  --name standard
+  --name standard \
   -p 80:80 -p 8021:21 -p 8800:8800 --tmpfs /var/run/ \
   --privileged=true \
   -e GALAXY_CONFIG_ALLOW_USER_DATASET_PURGE=True \

--- a/travis_scripts/before_install_docker.sh
+++ b/travis_scripts/before_install_docker.sh
@@ -6,6 +6,7 @@ pip --version
 pip install ansible
 ansible-galaxy install -r requirements_roles.yml -p roles
 mv extra-files/metavisitor/metavisitor_tool_list.yml.fortestonly extra-files/metavisitor/metavisitor_tool_list.yml
+printf "galaxy_runs_in_docker: yes\ngalaxy_docker_container_id: standard\n" >> group_vars/all
 sudo groupadd -r $GALAXY_TRAVIS_USER -g $GALAXY_GID
 sudo useradd -u $GALAXY_UID -r -g $GALAXY_TRAVIS_USER -d $GALAXY_HOME -p travis_testing\
   -c "Galaxy user" $GALAXY_TRAVIS_USER
@@ -15,6 +16,7 @@ docker build -t metavisitor .
 sudo mkdir /export && sudo chown $GALAXY_UID:$GALAXY_GID /export
 sudo mkdir /export2 && sudo chown $GALAXY_UID:$GALAXY_GID /export2
 export STANDARD=`docker run -d \
+  --name standard
   -p 80:80 -p 8021:21 -p 8800:8800 --tmpfs /var/run/ \
   --privileged=true \
   -e GALAXY_CONFIG_ALLOW_USER_DATASET_PURGE=True \

--- a/travis_scripts/before_install_docker.sh
+++ b/travis_scripts/before_install_docker.sh
@@ -3,7 +3,7 @@ set -e
 docker --version
 docker info
 pip --version
-pip install ansible==2.2
+pip install ansible
 ansible-galaxy install -r requirements_roles.yml -p roles
 mv extra-files/metavisitor/metavisitor_tool_list.yml.fortestonly extra-files/metavisitor/metavisitor_tool_list.yml
 sudo groupadd -r $GALAXY_TRAVIS_USER -g $GALAXY_GID

--- a/travis_scripts/script_docker.sh
+++ b/travis_scripts/script_docker.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 sleep 60s
-docker logs $STANDARD
+docker logs standard
 docker ps
 curl --fail $BIOBLEND_GALAXY_URL/api/version
 docker exec -it $STANDARD supervisorctl status


### PR DESCRIPTION
This PR is minor. It prefigures the use of run-data-managers to install genomes. However, I think it is simpler to design a separate role for this part while waiting for release_18.01 and reload of tool-data-table without restarting galaxy.

When this is done we will be able to use again the ansible-galaxy-tools role for both tools and genome/data-managers