### PR TITLE
Change bowtie2 version in workflows

### DIFF
--- a/extra-files/metavisitor/Galaxy-Workflow-Metavisitor__Spades_test_in_Use_Case_2-2.ga
+++ b/extra-files/metavisitor/Galaxy-Workflow-Metavisitor__Spades_test_in_Use_Case_2-2.ga
@@ -60,7 +60,7 @@
         }, 
         "2": {
             "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/bowtie2/bowtie2/2.3.3.1", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/bowtie2/bowtie2/2.3.2.2", 
             "errors": null, 
             "id": 2, 
             "input_connections": {
@@ -153,15 +153,15 @@
                     "output_name": "output_unaligned_reads_r"
                 }
             }, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/bowtie2/bowtie2/2.3.3.1", 
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/bowtie2/bowtie2/2.3.2.2", 
             "tool_shed_repository": {
-                "changeset_revision": "121110a12cc9", 
+                "changeset_revision": "66f992977578", 
                 "name": "bowtie2", 
                 "owner": "devteam", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
             "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"library\": \"{\\\"aligned_file\\\": \\\"false\\\", \\\"unaligned_file\\\": \\\"true\\\", \\\"type\\\": \\\"single\\\", \\\"__current_case__\\\": 0, \\\"input_1\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"reference_genome\": \"{\\\"source\\\": \\\"indexed\\\", \\\"__current_case__\\\": 0, \\\"index\\\": \\\"AgamP4\\\"}\", \"rg\": \"{\\\"rg_selector\\\": \\\"do_not_set\\\", \\\"__current_case__\\\": 3}\", \"save_mapping_stats\": \"\\\"false\\\"\", \"analysis_type\": \"{\\\"alignment_options\\\": {\\\"__current_case__\\\": 1, \\\"alignment_options_selector\\\": \\\"no\\\"}, \\\"effort_options\\\": {\\\"effort_options_selector\\\": \\\"no\\\", \\\"__current_case__\\\": 1}, \\\"sam_options\\\": {\\\"sam_options_selector\\\": \\\"no\\\", \\\"__current_case__\\\": 1}, \\\"other_options\\\": {\\\"other_options_selector\\\": \\\"no\\\", \\\"__current_case__\\\": 1}, \\\"scoring_options\\\": {\\\"scoring_options_selector\\\": \\\"no\\\", \\\"__current_case__\\\": 1}, \\\"analysis_type_selector\\\": \\\"full\\\", \\\"reporting_options\\\": {\\\"k\\\": \\\"1\\\", \\\"reporting_options_selector\\\": \\\"k\\\", \\\"__current_case__\\\": 1}, \\\"__current_case__\\\": 1, \\\"sam_opt\\\": \\\"true\\\", \\\"input_options\\\": {\\\"int_quals\\\": \\\"false\\\", \\\"solexa_quals\\\": \\\"false\\\", \\\"skip\\\": \\\"0\\\", \\\"input_options_selector\\\": \\\"yes\\\", \\\"qv_encoding\\\": \\\"--phred33\\\", \\\"__current_case__\\\": 0, \\\"trim3\\\": \\\"20\\\", \\\"qupto\\\": \\\"100000000\\\", \\\"trim5\\\": \\\"0\\\"}}\"}", 
-            "tool_version": "2.3.3.1", 
+            "tool_version": "2.3.2.2", 
             "type": "tool", 
             "uuid": "23f680f2-4891-4bea-a920-700ef1e95149", 
             "workflow_outputs": []
@@ -534,5 +534,5 @@
             ]
         }
     }, 
-    "uuid": "84d2c5a8-9b08-4aaf-bb43-76832f89de33"
+    "uuid": "a0be1f7c-075c-4fe2-b99e-3cfa46a10585"
 }

--- a/extra-files/metavisitor/Galaxy-Workflow-Metavisitor__Trinity_test_in_Use_Case_2-2.ga
+++ b/extra-files/metavisitor/Galaxy-Workflow-Metavisitor__Trinity_test_in_Use_Case_2-2.ga
@@ -60,7 +60,7 @@
         }, 
         "2": {
             "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/bowtie2/bowtie2/2.3.3.1", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/bowtie2/bowtie2/2.3.2.2", 
             "errors": null, 
             "id": 2, 
             "input_connections": {
@@ -153,15 +153,15 @@
                     "output_name": "output_unaligned_reads_r"
                 }
             }, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/bowtie2/bowtie2/2.3.3.1", 
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/bowtie2/bowtie2/2.3.2.2", 
             "tool_shed_repository": {
-                "changeset_revision": "121110a12cc9", 
+                "changeset_revision": "66f992977578", 
                 "name": "bowtie2", 
                 "owner": "devteam", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
             "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"library\": \"{\\\"aligned_file\\\": \\\"false\\\", \\\"unaligned_file\\\": \\\"true\\\", \\\"type\\\": \\\"single\\\", \\\"__current_case__\\\": 0, \\\"input_1\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"reference_genome\": \"{\\\"source\\\": \\\"indexed\\\", \\\"__current_case__\\\": 0, \\\"index\\\": \\\"AgamP4\\\"}\", \"rg\": \"{\\\"rg_selector\\\": \\\"do_not_set\\\", \\\"__current_case__\\\": 3}\", \"save_mapping_stats\": \"\\\"false\\\"\", \"analysis_type\": \"{\\\"alignment_options\\\": {\\\"__current_case__\\\": 1, \\\"alignment_options_selector\\\": \\\"no\\\"}, \\\"effort_options\\\": {\\\"effort_options_selector\\\": \\\"no\\\", \\\"__current_case__\\\": 1}, \\\"sam_options\\\": {\\\"sam_options_selector\\\": \\\"no\\\", \\\"__current_case__\\\": 1}, \\\"other_options\\\": {\\\"other_options_selector\\\": \\\"no\\\", \\\"__current_case__\\\": 1}, \\\"scoring_options\\\": {\\\"scoring_options_selector\\\": \\\"no\\\", \\\"__current_case__\\\": 1}, \\\"analysis_type_selector\\\": \\\"full\\\", \\\"reporting_options\\\": {\\\"k\\\": \\\"1\\\", \\\"reporting_options_selector\\\": \\\"k\\\", \\\"__current_case__\\\": 1}, \\\"__current_case__\\\": 1, \\\"sam_opt\\\": \\\"true\\\", \\\"input_options\\\": {\\\"int_quals\\\": \\\"false\\\", \\\"solexa_quals\\\": \\\"false\\\", \\\"skip\\\": \\\"0\\\", \\\"input_options_selector\\\": \\\"yes\\\", \\\"qv_encoding\\\": \\\"--phred33\\\", \\\"__current_case__\\\": 0, \\\"trim3\\\": \\\"20\\\", \\\"qupto\\\": \\\"100000000\\\", \\\"trim5\\\": \\\"0\\\"}}\"}", 
-            "tool_version": "2.3.3.1", 
+            "tool_version": "2.3.2.2", 
             "type": "tool", 
             "uuid": "39957bf7-f0bc-4e5d-80fa-39f00b156f8d", 
             "workflow_outputs": []
@@ -659,5 +659,5 @@
             ]
         }
     }, 
-    "uuid": "b636826e-a5f3-46b1-8464-d29cc930a7f0"
+    "uuid": "2b8ebf8a-92c9-4375-8661-d968effb7e29"
 }

--- a/extra-files/metavisitor/Galaxy-Workflow-Metavisitor__Workflow_for_Use_Case_2-2.ga
+++ b/extra-files/metavisitor/Galaxy-Workflow-Metavisitor__Workflow_for_Use_Case_2-2.ga
@@ -60,7 +60,7 @@
         }, 
         "2": {
             "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/bowtie2/bowtie2/2.3.3.1", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/bowtie2/bowtie2/2.3.2.2", 
             "errors": null, 
             "id": 2, 
             "input_connections": {
@@ -153,15 +153,15 @@
                     "output_name": "output_unaligned_reads_r"
                 }
             }, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/bowtie2/bowtie2/2.3.3.1", 
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/bowtie2/bowtie2/2.3.2.2", 
             "tool_shed_repository": {
-                "changeset_revision": "121110a12cc9", 
+                "changeset_revision": "66f992977578", 
                 "name": "bowtie2", 
                 "owner": "devteam", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
             "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"library\": \"{\\\"aligned_file\\\": \\\"false\\\", \\\"unaligned_file\\\": \\\"true\\\", \\\"type\\\": \\\"single\\\", \\\"__current_case__\\\": 0, \\\"input_1\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"reference_genome\": \"{\\\"source\\\": \\\"indexed\\\", \\\"__current_case__\\\": 0, \\\"index\\\": \\\"AgamP4\\\"}\", \"rg\": \"{\\\"rg_selector\\\": \\\"do_not_set\\\", \\\"__current_case__\\\": 3}\", \"save_mapping_stats\": \"\\\"false\\\"\", \"analysis_type\": \"{\\\"alignment_options\\\": {\\\"__current_case__\\\": 1, \\\"alignment_options_selector\\\": \\\"no\\\"}, \\\"effort_options\\\": {\\\"effort_options_selector\\\": \\\"no\\\", \\\"__current_case__\\\": 1}, \\\"sam_options\\\": {\\\"sam_options_selector\\\": \\\"no\\\", \\\"__current_case__\\\": 1}, \\\"other_options\\\": {\\\"other_options_selector\\\": \\\"no\\\", \\\"__current_case__\\\": 1}, \\\"scoring_options\\\": {\\\"scoring_options_selector\\\": \\\"no\\\", \\\"__current_case__\\\": 1}, \\\"analysis_type_selector\\\": \\\"full\\\", \\\"reporting_options\\\": {\\\"k\\\": \\\"1\\\", \\\"reporting_options_selector\\\": \\\"k\\\", \\\"__current_case__\\\": 1}, \\\"__current_case__\\\": 1, \\\"sam_opt\\\": \\\"true\\\", \\\"input_options\\\": {\\\"int_quals\\\": \\\"false\\\", \\\"solexa_quals\\\": \\\"false\\\", \\\"skip\\\": \\\"0\\\", \\\"input_options_selector\\\": \\\"yes\\\", \\\"qv_encoding\\\": \\\"--phred33\\\", \\\"__current_case__\\\": 0, \\\"trim3\\\": \\\"20\\\", \\\"qupto\\\": \\\"100000000\\\", \\\"trim5\\\": \\\"0\\\"}}\"}", 
-            "tool_version": "2.3.3.1", 
+            "tool_version": "2.3.2.2", 
             "type": "tool", 
             "uuid": "e957e1b6-7774-42ca-a23d-7170ac59795b", 
             "workflow_outputs": []
@@ -605,5 +605,5 @@
             ]
         }
     }, 
-    "uuid": "947d4fdc-3646-4623-9464-20e984957bf3"
+    "uuid": "e4af4f2b-9694-4c89-9710-da526d2a0875"
 }

--- a/extra-files/metavisitor/Galaxy-Workflow-Metavisitor__Workflow_for_Use_Case_3-2.ga
+++ b/extra-files/metavisitor/Galaxy-Workflow-Metavisitor__Workflow_for_Use_Case_3-2.ga
@@ -50,11 +50,17 @@
             "tool_version": null, 
             "type": "data_input", 
             "uuid": "a71a2de8-e3d1-41d7-88b1-15a4badddbd1", 
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null, 
+                    "output_name": "output", 
+                    "uuid": "879d9586-4960-4a9a-811a-539861b1bb5c"
+                }
+            ]
         }, 
         "2": {
             "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/bowtie2/bowtie2/2.3.3.1", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/bowtie2/bowtie2/2.3.2.2", 
             "errors": null, 
             "id": 2, 
             "input_connections": {
@@ -142,15 +148,15 @@
                     "output_name": "output_unaligned_reads_r"
                 }
             }, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/bowtie2/bowtie2/2.3.3.1", 
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/bowtie2/bowtie2/2.3.2.2", 
             "tool_shed_repository": {
-                "changeset_revision": "121110a12cc9", 
+                "changeset_revision": "66f992977578", 
                 "name": "bowtie2", 
                 "owner": "devteam", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
             "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"library\": \"{\\\"aligned_file\\\": \\\"false\\\", \\\"unaligned_file\\\": \\\"true\\\", \\\"type\\\": \\\"single\\\", \\\"__current_case__\\\": 0, \\\"input_1\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"reference_genome\": \"{\\\"source\\\": \\\"indexed\\\", \\\"__current_case__\\\": 0, \\\"index\\\": \\\"hg19\\\"}\", \"rg\": \"{\\\"rg_selector\\\": \\\"do_not_set\\\", \\\"__current_case__\\\": 3}\", \"save_mapping_stats\": \"\\\"false\\\"\", \"analysis_type\": \"{\\\"alignment_options\\\": {\\\"__current_case__\\\": 1, \\\"alignment_options_selector\\\": \\\"no\\\"}, \\\"effort_options\\\": {\\\"effort_options_selector\\\": \\\"no\\\", \\\"__current_case__\\\": 1}, \\\"sam_options\\\": {\\\"sam_options_selector\\\": \\\"no\\\", \\\"__current_case__\\\": 1}, \\\"other_options\\\": {\\\"other_options_selector\\\": \\\"no\\\", \\\"__current_case__\\\": 1}, \\\"scoring_options\\\": {\\\"scoring_options_selector\\\": \\\"no\\\", \\\"__current_case__\\\": 1}, \\\"analysis_type_selector\\\": \\\"full\\\", \\\"reporting_options\\\": {\\\"k\\\": \\\"1\\\", \\\"reporting_options_selector\\\": \\\"k\\\", \\\"__current_case__\\\": 1}, \\\"__current_case__\\\": 1, \\\"sam_opt\\\": \\\"true\\\", \\\"input_options\\\": {\\\"input_options_selector\\\": \\\"no\\\", \\\"__current_case__\\\": 1}}\"}", 
-            "tool_version": "2.3.3.1", 
+            "tool_version": "2.3.2.2", 
             "type": "tool", 
             "uuid": "034fd13d-f81e-40d6-98d4-6de709bf45fc", 
             "workflow_outputs": [
@@ -163,7 +169,7 @@
         }, 
         "3": {
             "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/bowtie2/bowtie2/2.3.3.1", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/bowtie2/bowtie2/2.3.2.2", 
             "errors": null, 
             "id": 3, 
             "input_connections": {
@@ -258,15 +264,15 @@
                     "output_name": "output_unaligned_reads_r"
                 }
             }, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/bowtie2/bowtie2/2.3.3.1", 
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/bowtie2/bowtie2/2.3.2.2", 
             "tool_shed_repository": {
-                "changeset_revision": "121110a12cc9", 
+                "changeset_revision": "66f992977578", 
                 "name": "bowtie2", 
                 "owner": "devteam", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
             "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"library\": \"{\\\"aligned_file\\\": \\\"true\\\", \\\"unaligned_file\\\": \\\"false\\\", \\\"type\\\": \\\"single\\\", \\\"__current_case__\\\": 0, \\\"input_1\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"reference_genome\": \"{\\\"source\\\": \\\"indexed\\\", \\\"__current_case__\\\": 0, \\\"index\\\": \\\"vir1\\\"}\", \"rg\": \"{\\\"rg_selector\\\": \\\"do_not_set\\\", \\\"__current_case__\\\": 3}\", \"save_mapping_stats\": \"\\\"false\\\"\", \"analysis_type\": \"{\\\"alignment_options\\\": {\\\"__current_case__\\\": 1, \\\"alignment_options_selector\\\": \\\"no\\\"}, \\\"effort_options\\\": {\\\"effort_options_selector\\\": \\\"no\\\", \\\"__current_case__\\\": 1}, \\\"sam_options\\\": {\\\"sam_options_selector\\\": \\\"no\\\", \\\"__current_case__\\\": 1}, \\\"other_options\\\": {\\\"other_options_selector\\\": \\\"no\\\", \\\"__current_case__\\\": 1}, \\\"scoring_options\\\": {\\\"scoring_options_selector\\\": \\\"no\\\", \\\"__current_case__\\\": 1}, \\\"analysis_type_selector\\\": \\\"full\\\", \\\"reporting_options\\\": {\\\"k\\\": \\\"1\\\", \\\"reporting_options_selector\\\": \\\"k\\\", \\\"__current_case__\\\": 1}, \\\"__current_case__\\\": 1, \\\"sam_opt\\\": \\\"true\\\", \\\"input_options\\\": {\\\"input_options_selector\\\": \\\"no\\\", \\\"__current_case__\\\": 1}}\"}", 
-            "tool_version": "2.3.3.1", 
+            "tool_version": "2.3.2.2", 
             "type": "tool", 
             "uuid": "4ff96083-3bd4-4341-9d99-932c345b6409", 
             "workflow_outputs": [
@@ -288,7 +294,12 @@
                     "output_name": "output_aligned_reads_l"
                 }
             }, 
-            "inputs": [], 
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool FASTQ to FASTA", 
+                    "name": "input_file"
+                }
+            ], 
             "label": null, 
             "name": "FASTQ to FASTA", 
             "outputs": [
@@ -315,7 +326,7 @@
                 "owner": "devteam", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
-            "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"input_file\": \"null\"}", 
+            "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"input_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", 
             "tool_version": "1.1.1", 
             "type": "tool", 
             "uuid": "41d312fb-2955-41eb-9b16-3163dbf2d01f", 
@@ -659,5 +670,5 @@
             ]
         }
     }, 
-    "uuid": "cb39afdc-fd9e-4ae7-a6c4-dd7b7802bc06"
+    "uuid": "bf7e29fb-f45a-4b2e-8598-000594c62b6c"
 }

--- a/extra-files/metavisitor/Galaxy-Workflow-Metavisitor__Workflow_for_Use_Case_3-3.ga
+++ b/extra-files/metavisitor/Galaxy-Workflow-Metavisitor__Workflow_for_Use_Case_3-3.ga
@@ -2,7 +2,7 @@
     "a_galaxy_workflow": "true", 
     "annotation": "", 
     "format-version": "0.1", 
-    "name": "Metavisitor: Workflow for Use Case 3-3", 
+    "name": "Metavisitor: Workflow for Use Case 3-3 old bowtie2", 
     "steps": {
         "0": {
             "annotation": "", 
@@ -115,7 +115,7 @@
         }, 
         "3": {
             "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/bowtie2/bowtie2/2.3.3.1", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/bowtie2/bowtie2/2.3.2.2", 
             "errors": null, 
             "id": 3, 
             "input_connections": {
@@ -208,15 +208,15 @@
                     "output_name": "output_unaligned_reads_r"
                 }
             }, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/bowtie2/bowtie2/2.3.3.1", 
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/bowtie2/bowtie2/2.3.2.2", 
             "tool_shed_repository": {
-                "changeset_revision": "121110a12cc9", 
+                "changeset_revision": "66f992977578", 
                 "name": "bowtie2", 
                 "owner": "devteam", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
             "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"library\": \"{\\\"aligned_file\\\": \\\"true\\\", \\\"unaligned_file\\\": \\\"false\\\", \\\"type\\\": \\\"single\\\", \\\"__current_case__\\\": 0, \\\"input_1\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"reference_genome\": \"{\\\"source\\\": \\\"indexed\\\", \\\"__current_case__\\\": 0, \\\"index\\\": \\\"vir1\\\"}\", \"rg\": \"{\\\"rg_selector\\\": \\\"do_not_set\\\", \\\"__current_case__\\\": 3}\", \"save_mapping_stats\": \"\\\"false\\\"\", \"analysis_type\": \"{\\\"alignment_options\\\": {\\\"__current_case__\\\": 1, \\\"alignment_options_selector\\\": \\\"no\\\"}, \\\"effort_options\\\": {\\\"effort_options_selector\\\": \\\"no\\\", \\\"__current_case__\\\": 1}, \\\"sam_options\\\": {\\\"sam_options_selector\\\": \\\"no\\\", \\\"__current_case__\\\": 1}, \\\"other_options\\\": {\\\"other_options_selector\\\": \\\"no\\\", \\\"__current_case__\\\": 1}, \\\"scoring_options\\\": {\\\"scoring_options_selector\\\": \\\"no\\\", \\\"__current_case__\\\": 1}, \\\"analysis_type_selector\\\": \\\"full\\\", \\\"reporting_options\\\": {\\\"k\\\": \\\"1\\\", \\\"reporting_options_selector\\\": \\\"k\\\", \\\"__current_case__\\\": 1}, \\\"__current_case__\\\": 1, \\\"sam_opt\\\": \\\"true\\\", \\\"input_options\\\": {\\\"input_options_selector\\\": \\\"no\\\", \\\"__current_case__\\\": 1}}\"}", 
-            "tool_version": "2.3.3.1", 
+            "tool_version": "2.3.2.2", 
             "type": "tool", 
             "uuid": "4d9c2aaa-0ae3-4c56-b055-303ae68dd839", 
             "workflow_outputs": []
@@ -768,5 +768,5 @@
             ]
         }
     }, 
-    "uuid": "3c095eb9-08d1-4103-80b2-3d64ea9fd8d2"
+    "uuid": "e04e98ab-fdc2-4e1d-b66d-80499f9932f5"
 }

--- a/extra-files/metavisitor/Galaxy-Workflow-Metavisitor__Workflow_for_Use_Case_3-3.ga
+++ b/extra-files/metavisitor/Galaxy-Workflow-Metavisitor__Workflow_for_Use_Case_3-3.ga
@@ -2,7 +2,7 @@
     "a_galaxy_workflow": "true", 
     "annotation": "", 
     "format-version": "0.1", 
-    "name": "Metavisitor: Workflow for Use Case 3-3 old bowtie2", 
+    "name": "Metavisitor: Workflow for Use Case 3-3", 
     "steps": {
         "0": {
             "annotation": "", 


### PR DESCRIPTION
Bowtie 2.3.3 has a [problem when reading some fastq files](https://github.com/galaxyproject/tools-iuc/issues/1640) so the Bowtie2 version was changed to the latest version capable of running the workflows as described in the [Metavisitor manual](https://artbio.github.io/Metavisitor-manual/). Which is version 2.3.2