### PR TITLE
Add a role to GalaxyKickStart to run data-managers

### DIFF
--- a/extra-files/docker/galaxykickstart_docker_tool_list.yml
+++ b/extra-files/docker/galaxykickstart_docker_tool_list.yml
@@ -1,6 +1,11 @@
 tools:
-- name: justdiff
-  owner: artbio
-  revisions:
-    - 9299a59defda
-  tool_panel_section_label: 'GalaxyKickStart'
+- name: data_manager_fetch_genome_dbkeys_all_fasta
+  owner: devteam
+  tool_panel_section_label: 'Data Managers'
+  tool_shed_url: https://toolshed.g2.bx.psu.edu/
+  install_resolver_dependencies: True
+
+- name: data_manager_bowtie2_index_builder
+  owner: devteam
+  tool_panel_section_label: 'Data Managers'
+  tool_shed_url: https://toolshed.g2.bx.psu.edu/

--- a/extra-files/galaxy-kickstart/galaxy-kickstart_tool_list.yml
+++ b/extra-files/galaxy-kickstart/galaxy-kickstart_tool_list.yml
@@ -5,3 +5,8 @@ tools:
   tool_panel_section_label: 'Data Managers'
   tool_shed_url: https://toolshed.g2.bx.psu.edu/
   install_resolver_dependencies: True
+
+- name: data_manager_bowtie2_index_builder
+  owner: devteam
+  tool_panel_section_label: 'Data Managers'
+  tool_shed_url: https://toolshed.g2.bx.psu.edu/

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -96,6 +96,11 @@
       become_user: "{{ galaxy_user_name }}"
       tags: install_tools
 
+    - role: run_data_manager_role
+      tags:
+        - install_data_managers
+      when: gks_run_data_managers
+
   post_tasks:
     - name: Clean apt cache to recover some disk space
       shell: apt-get clean

--- a/group_vars/all
+++ b/group_vars/all
@@ -3,6 +3,7 @@ proxy_env: {}
 install_galaxy: true
 install_maintainance_packages: false
 galaxy_manage_trackster: true
+gks_run_data_managers: true
 galaxy_hostname: "{{ inventory_hostname }}"
 nginx_galaxy_location: ""
 galaxy_user_name: galaxy

--- a/roles/run_data_manager_role/defaults/main.yml
+++ b/roles/run_data_manager_role/defaults/main.yml
@@ -1,0 +1,28 @@
+gks_run_data_managers: yes
+
+# A URL or an IP address for the Galaxy instance where the tools are to be
+# installed
+galaxy_tools_galaxy_instance_url: http://127.0.0.1:8080
+
+# A yml file that lists the data-managers and genomes to be installed
+# see `files/tool_list.yaml.sample`
+gks_data_managers_list: "run_data_managers_list.yaml"
+
+# A system path from where this role will be run
+galaxy_tools_base_dir: /tmp
+
+# Set this to yes and change galaxy_tools_api_key to a string to create a predefined api key for the bootstrap user.
+galaxy_tools_admin_user_preset_api_key: no
+
+# Blank variable to make sure it's defined
+galaxy_tools_api_key: ''
+
+# User name for the system galaxy user
+galaxy_user_name: galaxy
+
+# A system path where a virtualenv for Galaxy is installed
+galaxy_venv_dir: "{{ galaxy_server_dir }}/.venv"
+
+# A system path for Galaxy's main configuration file
+galaxy_config_file: "{{ galaxy_server_dir }}/config/galaxy.ini"
+

--- a/roles/run_data_manager_role/files/run_data_managers_list.yaml
+++ b/roles/run_data_manager_role/files/run_data_managers_list.yaml
@@ -1,0 +1,39 @@
+# configuration for fetch and index genomes
+
+data_managers:
+    # Data manager ID
+    - id: toolshed.g2.bx.psu.edu/repos/devteam/data_manager_fetch_genome_dbkeys_all_fasta/data_manager_fetch_genome_all_fasta_dbkey/0.0.2
+      # tool parameters, nested parameters should be specified using a pipe (|)
+      params:
+        - 'dbkey_source|dbkey': '{{ item }}'
+        - 'reference_source|reference_source_selector': 'ucsc'
+        - 'reference_source|requested_dbkey': '{{ item }}'
+      # Items refere to a list of variables you want to run this data manager. You can use them inside the param field with {{ item }}
+      # In case of genome for example you can run this DM with multiple genomes, or you could give multiple URLs.
+      items:
+        - ce6
+        #- dm3
+        #- mm9
+      # Name of the data-tables you want to reload after your DM are finished. This can be important for subsequent data managers
+      data_table_reload:
+        - all_fasta
+        - __dbkeys__
+
+#    - id: toolshed.g2.bx.psu.edu/repos/devteam/data_manager_bowtie2_index_builder/bowtie2_index_builder_data_manager/2.2.6
+#      params:
+#        - 'all_fasta_source': '{{ item.id }}'
+#        - 'sequence_name': '{{ item.name }}'
+#        - 'sequence_id': '{{ item.id }}'
+#      items:
+#        - id: ce8
+#          name: C. elegans (ce8)
+#        - id: dm3
+#          name: D. melanogaster Apr. 2006 (BDGP r5/dm3)
+#        - id: mm9
+#          name: M. musculus July 2007 (NCBI37/mm9)
+#      data_table_reload:
+#        # Bowtie creates indices for Bowtie and TopHat
+#        - bowtie2_indexes
+#        - tophat2_indexesimac-chris:run_data_manager_role
+
+

--- a/roles/run_data_manager_role/files/run_data_managers_list.yaml
+++ b/roles/run_data_manager_role/files/run_data_managers_list.yaml
@@ -19,7 +19,7 @@ data_managers:
         - all_fasta
         - __dbkeys__
 
-    - id: toolshed.g2.bx.psu.edu/repos/devteam/data_manager_bowtie2_index_builder/bowtie2_index_builder_data_manager/2.2.6
+    - id: toolshed.g2.bx.psu.edu/repos/devteam/data_manager_bowtie2_index_builder/bowtie2_index_builder_data_manager/2.3.0
       params:
         - 'all_fasta_source': '{{ item.id }}'
         - 'sequence_name': '{{ item.name }}'

--- a/roles/run_data_manager_role/files/run_data_managers_list.yaml
+++ b/roles/run_data_manager_role/files/run_data_managers_list.yaml
@@ -19,21 +19,21 @@ data_managers:
         - all_fasta
         - __dbkeys__
 
-#    - id: toolshed.g2.bx.psu.edu/repos/devteam/data_manager_bowtie2_index_builder/bowtie2_index_builder_data_manager/2.2.6
-#      params:
-#        - 'all_fasta_source': '{{ item.id }}'
-#        - 'sequence_name': '{{ item.name }}'
-#        - 'sequence_id': '{{ item.id }}'
-#      items:
-#        - id: ce8
-#          name: C. elegans (ce8)
+    - id: toolshed.g2.bx.psu.edu/repos/devteam/data_manager_bowtie2_index_builder/bowtie2_index_builder_data_manager/2.2.6
+      params:
+        - 'all_fasta_source': '{{ item.id }}'
+        - 'sequence_name': '{{ item.name }}'
+        - 'sequence_id': '{{ item.id }}'
+      items:
+        - id: ce6
+          name: C. elegans (ce6)
 #        - id: dm3
 #          name: D. melanogaster Apr. 2006 (BDGP r5/dm3)
 #        - id: mm9
 #          name: M. musculus July 2007 (NCBI37/mm9)
-#      data_table_reload:
-#        # Bowtie creates indices for Bowtie and TopHat
-#        - bowtie2_indexes
+      data_table_reload:
+        # Bowtie creates indices for Bowtie and TopHat
+        - bowtie2_indexes
 #        - tophat2_indexesimac-chris:run_data_manager_role
 
 

--- a/roles/run_data_manager_role/tasks/gks_install_data_managers.yml
+++ b/roles/run_data_manager_role/tasks/gks_install_data_managers.yml
@@ -1,0 +1,32 @@
+- name: Restart Supervisorctl Galaxy
+  supervisorctl: name="galaxy:" state=restarted
+  ignore_errors: yes
+  become: yes
+  become_user: root
+
+- pause:
+    seconds: 5
+
+- name: Create/invoke script virtualenv
+  pip: name={{ item }} virtualenv={{ galaxy_tools_base_dir }}/venv virtualenv_command="{{ pip_virtualenv_command | default( 'virtualenv' ) }}"
+  with_items:
+    - ephemeris==0.8.0  # Pinned version should make sure ephemeris version matches what the role has been tested with
+    - bioblend==0.10.0
+
+- name: Copy galaxy_tools_data_managers_list in venv
+  copy: src="{{ gks_data_managers_list }}" dest="{{ galaxy_tools_base_dir }}/venv/bin/data_managers_list.yaml"
+
+- name: Install Data-managers and Genomes
+  command: '{{ galaxy_tools_base_dir }}/venv/bin/run-data-managers -a "{{ galaxy_tools_api_key }}" -g "{{ galaxy_tools_galaxy_instance_url }}" --config "{{ galaxy_tools_base_dir }}/venv/bin/data_managers_list.yaml" '
+  register: install_result
+  changed_when: "install_result.stderr.find('Failed jobs: 0') != -1"
+  failed_when: "(install_result.stderr.find('Tool not found or not accessible') != -1) or not(install_result.stderr.find('Failed jobs: 0') != -1) or (install_result.rc != 0)"
+  ignore_errors: "{{ galaxy_tools_ignore_errors }}"
+#  notify:  # may have to notify something
+#    - ansible-galaxy-tools restart galaxy
+
+- name: Display data_managers results
+  debug:
+    msg:
+      - "{{ install_result.stderr }}"
+      - "{{ install_result.stdout }}"

--- a/roles/run_data_manager_role/tasks/main.yml
+++ b/roles/run_data_manager_role/tasks/main.yml
@@ -1,0 +1,2 @@
+- include: gks_install_data_managers.yml
+  when: gks_run_data_managers

--- a/travis_scripts/script_docker.sh
+++ b/travis_scripts/script_docker.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -e
-sleep 60s
-docker logs $CID2
+echo -e "sleeping 120s, zzzzzz"
+sleep 120s
+# docker logs $CID2
 curl http://localhost:8181/subdir/api/version| grep version_major
 sudo -E su $GALAXY_TRAVIS_USER -c "export PATH=$GALAXY_HOME/.local/bin/:$PATH &&
   cd $GALAXY_HOME &&
@@ -11,7 +12,7 @@ date > $HOME/date.txt && curl --fail -T $HOME/date.txt ftp://localhost:8021 --us
 curl --fail ftp://localhost:8021 --user $GALAXY_USER:$GALAXY_USER_PASSWD
 docker exec -it $CID1 supervisorctl status | grep proftpd | grep RUNNING
 docker stop $CID1 $CID2 && docker rm $CID1 $CID2
-CID3=`docker run -d --privileged=true -p 8181:80 -e NAT_MASQUERADE=true -v /export2:/export galaxy_kickstart` && sleep 60s
+CID3=`docker run -d --privileged=true -p 8181:80 -e NAT_MASQUERADE=true -v /export2:/export galaxy_kickstart` && sleep 120s
 docker logs $CID3
 curl http://localhost:8181/api/version| grep version_major
 cd $TRAVIS_BUILD_DIR


### PR DESCRIPTION
Currently, the corresponding task in galaxy-tools is https://github.com/ARTbio/ansible-galaxy-tools/blob/master/tasks/data_managers.yml and does not work when more than one genome indexes have to be produced. 

With next galaxy releases we should be able to reload tool-data-tables without restarting galaxy.
When this is done we will be able to use again the ansible-galaxy-tools role for both tools and genome/data-managers.