### PR TITLE
Pin all upstream roles in ARTbio repos

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -71,6 +71,7 @@ supervisor_env_vars:
 galaxy_persistent_directory: /export # for IFB it's /root/mydisk, by default, /export
 galaxy_manage_mutable_setup: yes
 galaxy_mutable_config_dir: "{{ galaxy_config_dir }}"
+galaxy_config_style: "ini-paste"
 galaxy_config_file: "{{ galaxy_config_dir }}/galaxy.ini"
 #other vars
 galaxy_manage_database: yes

--- a/requirements_roles.yml
+++ b/requirements_roles.yml
@@ -1,23 +1,23 @@
-- src: https://github.com/galaxyproject/ansible-galaxy-os.git
+- src: https://github.com/ARTbio/ansible-galaxy-os.git
   name: galaxyprojectdotorg.galaxy-os
 
 - src: https://github.com/ARTbio/ensure_postgresql_up.git
   name: ensure_postgresql_up
 
-- src: https://github.com/natefoo/ansible-postgresql-objects.git
+- src: https://github.com/ARTbio/ansible-postgresql-objects.git
   name: natefoo.postgresql_objects
 
-- src: https://github.com/galaxyproject/ansible-galaxy.git
+- src: https://github.com/ARTbio/ansible-galaxy.git
   name: galaxyprojectdotorg.galaxy
 
 - src: https://github.com/ARTbio/ansible-galaxy-extras.git
   name: galaxyprojectdotorg.galaxy-extras
 
-- src: https://github.com/galaxyproject/ansible-trackster.git
+- src: https://github.com/ARTbio/ansible-trackster.git
   name: galaxyprojectdotorg.trackster
 
-- src: https://github.com/galaxyproject/ansible-galaxy-tools.git
+- src: https://github.com/ARTbio/ansible-galaxy-tools.git
   name: galaxyprojectdotorg.galaxy-tools
 
-- src: https://github.com/uchida/ansible-miniconda-role.git
+- src: https://github.com/ARTbio/ansible-miniconda-role.git
   name: miniconda-role

--- a/requirements_roles.yml
+++ b/requirements_roles.yml
@@ -12,6 +12,7 @@
 
 - src: https://github.com/ARTbio/ansible-galaxy-extras.git
   name: galaxyprojectdotorg.galaxy-extras
+  version: updating
 
 - src: https://github.com/galaxyproject/ansible-trackster.git
   name: galaxyprojectdotorg.trackster

--- a/requirements_roles.yml
+++ b/requirements_roles.yml
@@ -12,7 +12,6 @@
 
 - src: https://github.com/ARTbio/ansible-galaxy-extras.git
   name: galaxyprojectdotorg.galaxy-extras
-  version: updating
 
 - src: https://github.com/galaxyproject/ansible-trackster.git
   name: galaxyprojectdotorg.trackster


### PR DESCRIPTION
New organisation to isolate GalaxyKickStart from untested changes in upstream roles:

- All upstream roles are forked in ARTbio
- Master branches of forked roles are the tested / working branches and won't be updated before effective testing. `requirements_roles.yml` points to these branches.
- In forks, a branch `galaxyproject` (or organisation/user name of the origin) is synchronised with the origin/master and serves for testing purpose.
- other branches in forks are used to propose developments/fixes

- [x] - src: https://github.com/galaxyproject/ansible-galaxy-os.git
      name: galaxyprojectdotorg.galaxy-os
- [x] - src: https://github.com/ARTbio/ensure_postgresql_up.git
      name: ensure_postgresql_up
- [x] - src: https://github.com/natefoo/ansible-postgresql-objects.git
      name: natefoo.postgresql_objects
- [x] - src: https://github.com/galaxyproject/ansible-galaxy.git
      name: galaxyprojectdotorg.galaxy
- [x] - src: https://github.com/ARTbio/ansible-galaxy-extras.git
      name: galaxyprojectdotorg.galaxy-extras
- [x] - src: https://github.com/galaxyproject/ansible-trackster.git
      name: galaxyprojectdotorg.trackster
- [x] - src: https://github.com/galaxyproject/ansible-galaxy-tools.git
      name: galaxyprojectdotorg.galaxy-tools
- [x] - src: https://github.com/uchida/ansible-miniconda-role.git
      name: miniconda-role
