### PR TITLE
release_18.05

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -2,7 +2,7 @@ GKS: true
 proxy_env: {}
 install_galaxy: true
 install_maintainance_packages: false
-galaxy_manage_trackster: true
+galaxy_manage_trackster: false
 gks_run_data_managers: false
 galaxy_hostname: "{{ inventory_hostname }}"
 nginx_galaxy_location: ""
@@ -18,7 +18,7 @@ galaxy_config_dir: "{{ galaxy_server_dir }}/config"
 galaxy_database: /home/galaxy_database
 galaxy_db: postgresql://{{ galaxy_user_name }}:{{ galaxy_user_name }}@localhost:5432/galaxy?client_encoding=utf8
 galaxy_git_repo: https://github.com/galaxyproject/galaxy.git
-galaxy_changeset_id: release_17.09
+galaxy_changeset_id: release_18.05
 galaxy_reports_config_file: "{{ galaxy_config_dir }}/reports.yml.sample"  # Change this to "{{ galaxy_config_dir }}/reports.ini.sample" for galaxy < 17.09
 galaxy_admin: admin@galaxy.org
 galaxy_admin_pw: admin
@@ -43,7 +43,7 @@ shed_tools_dir: "{{ galaxy_server_dir }}/../shed_tools"
 tool_data_dir: "{{ galaxy_server_dir  }}/tool-data"
 galaxy_mutable_data_dir: "{{ galaxy_server_dir  }}/database"
 miniconda_python: 3
-miniconda_version: "4.3.30"
+miniconda_version: "4.5.4"
 miniconda_installer_checksum: ""
 miniconda_prefix: "{{ tool_dependency_dir }}/_conda"
 miniconda_manage_dependencies: False


### PR DESCRIPTION
- change release version of Galaxy to release_18.05
- update miniconda version
- remove trackster from the default configuration
- This version still uses galaxy.ini (instead of galaxy.yml)