### PR TITLE
Xenial / 1805 for test environments and for docker buids

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python: 2.7
-dist: trusty
+dist: xenial
 sudo: required
 
 env:

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,8 +8,8 @@
     - include_tasks: roles/handlers/galaxy.yml
 
   pre_tasks:
-    - fail: msg="Installed ansible version {{ ansible_version.full }}, but ansible version >= 2.4 required"
-      when: ansible_version.full | version_compare('2.4.0.0', '<')
+    - fail: msg="Installed ansible version {{ ansible_version.full }}, but ansible version >= 2.7 required"
+      when: ansible_version.full is version_compare('2.7', '<')
       tags:
         - always
 

--- a/group_vars/all
+++ b/group_vars/all
@@ -18,7 +18,7 @@ galaxy_config_dir: "{{ galaxy_server_dir }}/config"
 galaxy_database: /home/galaxy_database
 galaxy_db: postgresql://{{ galaxy_user_name }}:{{ galaxy_user_name }}@localhost:5432/galaxy?client_encoding=utf8
 galaxy_git_repo: https://github.com/galaxyproject/galaxy.git
-galaxy_changeset_id: release_18.05
+galaxy_changeset_id: release_18.09
 galaxy_reports_config_file: "{{ galaxy_config_dir }}/reports.yml.sample"  # Change this to "{{ galaxy_config_dir }}/reports.ini.sample" for galaxy < 17.09
 galaxy_admin: admin@galaxy.org
 galaxy_admin_pw: admin

--- a/group_vars/all
+++ b/group_vars/all
@@ -18,7 +18,7 @@ galaxy_config_dir: "{{ galaxy_server_dir }}/config"
 galaxy_database: /home/galaxy_database
 galaxy_db: postgresql://{{ galaxy_user_name }}:{{ galaxy_user_name }}@localhost:5432/galaxy?client_encoding=utf8
 galaxy_git_repo: https://github.com/galaxyproject/galaxy.git
-galaxy_changeset_id: release_18.09
+galaxy_changeset_id: release_18.05
 galaxy_reports_config_file: "{{ galaxy_config_dir }}/reports.yml.sample"  # Change this to "{{ galaxy_config_dir }}/reports.ini.sample" for galaxy < 17.09
 galaxy_admin: admin@galaxy.org
 galaxy_admin_pw: admin

--- a/travis_scripts/before_install_docker.sh
+++ b/travis_scripts/before_install_docker.sh
@@ -2,16 +2,16 @@
 set -e
 docker --version
 docker info
-ansible-galaxy install -r requirements_roles.yml -p roles
+ansible-galaxy install -r requirements_roles.yml -p roles -f
 sudo groupadd -r $GALAXY_TRAVIS_USER -g $GALAXY_GID
-sudo useradd -u $GALAXY_UID -r -g $GALAXY_TRAVIS_USER -d $GALAXY_HOME -p travis_testing\
+sudo useradd -u $GALAXY_UID -r -g $GALAXY_TRAVIS_USER -d $GALAXY_HOME -p travis_testing \
   -c "Galaxy user" $GALAXY_TRAVIS_USER
 sudo mkdir $GALAXY_HOME
 sudo chown -R $GALAXY_TRAVIS_USER:$GALAXY_TRAVIS_USER $GALAXY_HOME
 docker build -t galaxy_kickstart -f Dockerfile.galaxykickstart-base .
 sudo mkdir /export && sudo chown $GALAXY_UID:$GALAXY_GID /export
 sudo mkdir /export2 && sudo chown $GALAXY_UID:$GALAXY_GID /export2
-export CID1=`docker run -d --privileged=true -p 80:80 -p 21:21\
+export CID1=`docker run -d --privileged=true -p 80:80 -p 21:21 \
   -e NAT_MASQUERADE=true \
   -e NGINX_GALAXY_LOCATION=/subdir \
   -v /tmp/:/tmp/ \

--- a/travis_scripts/script_docker.sh
+++ b/travis_scripts/script_docker.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 echo -e "sleeping 120s, zzzzzz"
-sleep 180s
+sleep 120s
 docker logs $CID1
 echo -e "Testing CID1 $CID1"
 curl http://localhost:80/subdir/api/version| grep version_major


### PR DESCRIPTION
- Travis runs in dist=xenial
- docker testing is performed on a new docker image ansible-galaxy-os:16.04 built from artbio:ansible-galaxy-os branch `ubuntu-xenial`
- `Dockerfile.galaxykickstart-base` file is updated accordingly for docker build
- ansible > 2.7 required
- points on a specific ubuntu-xenial branch of [ansible-galaxy-os](https://github.com/ARTbio/ansible-galaxy-os.git)