### PR TITLE
add missing sudo in doc

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -28,7 +28,7 @@ pip 9.0.1 from /usr/local/lib/python2.7/site-packages (python 2.7)
 - Then
 
 ```
-sudo pip install ansible
+sudo pip install ansible==2.7.4
 ```
 ### Install Ansible with apt
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -28,7 +28,7 @@ pip 9.0.1 from /usr/local/lib/python2.7/site-packages (python 2.7)
 - Then
 
 ```
-sudo pip install ansible==2.4
+sudo pip install ansible
 ```
 ### Install Ansible with apt
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -28,7 +28,7 @@ pip 9.0.1 from /usr/local/lib/python2.7/site-packages (python 2.7)
 - Then
 
 ```
-pip install ansible==2.4
+sudo pip install ansible==2.4
 ```
 ### Install Ansible with apt
 


### PR DESCRIPTION
missing sudo in ansible installation

when done as specified in the doc:

`Could not install packages due to an EnvironmentError: [Errno 13] Permission denied`