### PR TITLE
fix ansible improve reliability of install_tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,7 @@ jobs:
         - BIOBLEND_GALAXY_URL="http://localhost:80"
 
 before_install:
-  - sudo apt-add-repository -y ppa:ansible/ansible
-  - sudo apt-get -qq update
-  - sudo apt-get -qq install ansible
+  - pip install ansible==2.7.4
   - if [[ "$TRAVIS_BRANCH" == *"test_upstream_ansibles"* ]]; then mv upstream_requirements_roles.yml requirements_roles.yml; fi
   - if [ "$TRAVIS_JOB" = "ansible-test" ]; then . ./travis_scripts/before_install_ansible.sh; fi
   - if [ "$TRAVIS_JOB" = "docker-build" ]; then . ./travis_scripts/before_install_docker.sh; fi

--- a/travis_scripts/script_ansible.sh
+++ b/travis_scripts/script_ansible.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 set -e
-ansible-playbook -i inventory_files/galaxy-kickstart galaxy.yml
-sleep 60s
+ansible-playbook -i inventory_files/galaxy-kickstart --skip-tags=install_tools galaxy.yml
+ansible-playbook -i inventory_files/galaxy-kickstart --tags=install_tools galaxy.yml
+sleep 10s
+ansible-playbook -i inventory_files/galaxy-kickstart --tags=install_tools galaxy.yml
+sleep 10s
 curl http://localhost:80/api/version| grep version_major
 date > $HOME/date.txt && curl --fail -T $HOME/date.txt ftp://localhost:21 --user $GALAXY_USER:$GALAXY_USER_PASSWD
 sudo -E su $GALAXY_TRAVIS_USER -c "export PATH=$GALAXY_HOME/.local/bin/:$PATH &&


### PR DESCRIPTION
release_19.01 has failing install_tools tasks. This can be fixed in travis test by running twice the install_tools role.