### PR TITLE
GalaxyKickStart uses release_19.09

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -29,7 +29,7 @@ galaxy_config_dir: "{{ galaxy_server_dir }}/config"
 galaxy_database: /home/galaxy_database
 galaxy_db: postgresql://{{ galaxy_user_name }}:{{ galaxy_user_name }}@localhost:5432/galaxy?client_encoding=utf8
 galaxy_git_repo: https://github.com/galaxyproject/galaxy.git
-galaxy_changeset_id: release_19.05
+galaxy_changeset_id: release_19.09
 galaxy_reports_config_file: "{{ galaxy_config_dir }}/reports.yml.sample"  # Change this to "{{ galaxy_config_dir }}/reports.ini.sample" for galaxy < 17.09
 galaxy_admin: admin@galaxy.org
 galaxy_admin_pw: admin

--- a/requirements_roles.yml
+++ b/requirements_roles.yml
@@ -12,11 +12,11 @@
 
 - src: https://github.com/artbio/ansible-galaxy.git
   name: galaxyprojectdotorg.galaxy
-  version: galaxykickstart
+  version: add_conf_file_templates
 
 - src: https://github.com/artbio/ansible-galaxy-extras.git
   name: galaxyprojectdotorg.galaxy-extras
-  version: galaxykickstart 
+  version: fix_nginx_conf
 
 - src: https://github.com/artbio/ansible-trackster.git
   name: galaxyprojectdotorg.trackster


### PR DESCRIPTION
including changes in ansible-galaxy and ansible-galaxy-extras pointing to the corresponding artbio forks.

Contains a fix to the issue of setuptools (to pin to 44.0.0)