### PR TITLE
Update Dockerfile.galaxykickstart-base

### DIFF
--- a/Dockerfile.galaxykickstart-base
+++ b/Dockerfile.galaxykickstart-base
@@ -1,4 +1,4 @@
-FROM artbio/ansible-galaxy-os:1604
+FROM artbio/ansible-galaxy-os:1804
 
 LABEL maintainer_2="Christophe Antoniewski <drosofff@gmail.com>"
 


### PR DESCRIPTION
built on the galaxy-ansible-os:1804 docker image