### PR TITLE
Update job_conf.xml

### DIFF
--- a/extra-files/Artbio/job_conf.xml
+++ b/extra-files/Artbio/job_conf.xml
@@ -70,8 +70,8 @@
             </destination>
             <destination id="java_cluster" runner="slurm">
             <env file="/home/galaxy/galaxy/.venv/bin/activate"/>
-            <env id="_JAVA_OPTIONS">-Xmx40g</env>
-            <env id="_JAVA_OPTIONS">-Xms512m</env>
+            <env id="_JAVA_OPTIONS">-Xmx8192m</env>
+            <env id="_JAVA_OPTIONS">-Xms8192m</env>
             <param id="enabled" from_environ="GALAXY_RUNNERS_ENABLE_SLURM">true</param>
             <param id="nativeSpecification">--ntasks=4 --share</param>
         </destination>


### PR DESCRIPTION
Les annotations lancées par l'outil snpsift annotate developpé par l'iuc ressortent tous avec des "memory errors" 
` Picked up _JAVA_OPTIONS: -Xms512m Exception in thread "main" java.lang.OutOfMemoryError: Java heap space `
Après avoir investigué pour trouver les paramètres les plus adéquats, je suis arrivée à la conclusion de
1. suivre les recommandations Oracle d'avoir les paramètres Xmx et Xms identitiques : https://docs.oracle.com/cd/E12839_01/web.1111/e13814/jvm_tuning.htm#PERFM161   "Oracle recommends setting the minimum heap size (-Xms) equal to the maximum heap size (-Xmx) to minimize garbage collections." 
2. prendre en valeur 8G qui est la valeur "par défaut" par l'IUC pour les outils SnpEff https://github.com/galaxyproject/tools-iuc/blob/master/tool_collections/snpeff/snpEff_macros.xml#L20