### PR TITLE
Add Arriba tool suite

### DIFF
--- a/extra-files/Conect/conect_tool_list.yml
+++ b/extra-files/Conect/conect_tool_list.yml
@@ -1289,3 +1289,8 @@ tools:
   tool_panel_section_id: genefusions
   tool_panel_section_label: Gene fusions
   tool_shed_url: toolshed.g2.bx.psu.edu
+- name: star_fusion
+  owner: iuc
+  tool_panel_section_id: genefusions
+  tool_panel_section_label: Gene fusions
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/extra-files/Conect/conect_tool_list.yml
+++ b/extra-files/Conect/conect_tool_list.yml
@@ -1269,8 +1269,23 @@ tools:
   tool_panel_section_id: None
   tool_panel_section_label: None
   tool_shed_url: toolshed.g2.bx.psu.edu
- - name: suite_arriba
+- name: arriba
   owner: jjohnson
-  tool_panel_section_id: genefusion
-  tool_panel_section_label: Gene fusion
+  tool_panel_section_id: genefusions
+  tool_panel_section_label: Gene fusions
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: arriba_download_reference
+  owner: jjohnson
+  tool_panel_section_id: genefusions
+  tool_panel_section_label: Gene fusions
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: arriba_draw_fusions
+  owner: jjohnson
+  tool_panel_section_id: genefusions
+  tool_panel_section_label: Gene fusions
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: arriba_get_filters
+  owner: jjohnson
+  tool_panel_section_id: genefusions
+  tool_panel_section_label: Gene fusions
   tool_shed_url: toolshed.g2.bx.psu.edu

--- a/extra-files/Conect/conect_tool_list.yml
+++ b/extra-files/Conect/conect_tool_list.yml
@@ -1269,3 +1269,8 @@ tools:
   tool_panel_section_id: None
   tool_panel_section_label: None
   tool_shed_url: toolshed.g2.bx.psu.edu
+ - name: suite_arriba
+  owner: jjohnson
+  tool_panel_section_id: genefusion
+  tool_panel_section_label: Gene fusion
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/extra-files/Conect/conect_tool_list.yml
+++ b/extra-files/Conect/conect_tool_list.yml
@@ -1294,3 +1294,8 @@ tools:
   tool_panel_section_id: genefusions
   tool_panel_section_label: Gene fusions
   tool_shed_url: toolshed.g2.bx.psu.edu
+- name: data_manager_star_index_builder
+  owner: iuc
+  tool_panel_section_id: None
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu


### PR DESCRIPTION
To detect RNAseq gene fusions
J'ai 2 questions @drosofff : 
1. est ce que ça pose un problème de mettre le lien de la tool suite d'arriba ou vaut-il mieux mettre tous les outils de la suite de manière indépendante?
2. j'ai créé dans le yaml une nouvelle section Gene Fusion qui n'existait pas, on peut revoir ensemble le nom 
